### PR TITLE
Expand timeout value.

### DIFF
--- a/local-time-element.js
+++ b/local-time-element.js
@@ -198,7 +198,7 @@
     }
   }
 
-  setInterval(updateFromNowLocalTimeElements, 60000);
+  setInterval(updateFromNowLocalTimeElements, 60 * 1000);
 
   // Public: LocalTimeElement constructor.
   //


### PR DESCRIPTION
Makes the value a little more self-documenting as 60 seconds.
