### PR TITLE
Many places in the world are east of Greenwich.

### DIFF
--- a/test/local-time.js
+++ b/test/local-time.js
@@ -23,7 +23,7 @@ test('getFormattedDate with %z timezone offset', function() {
   var time = document.createElement('time', 'local-time');
   time.setAttribute('datetime', '1970-01-01T00:00:00.000Z');
   time.setAttribute('format', '%z');
-  ok(time.getFormattedDate().match(/\-\d\d\d\d/)[0]);
+  ok(time.getFormattedDate().match(/[+-]\d\d\d\d/)[0]);
 });
 
 test('ignores contents if datetime attribute is missing', function() {

--- a/time-elements.js
+++ b/time-elements.js
@@ -78,7 +78,7 @@
           match = time.toString().match(/\((\w+)\)$/);
           return match ? match[1] : '';
         case 'z':
-          match = time.toString().match(/\w(\-\d\d\d\d) /);
+          match = time.toString().match(/\w([+-]\d\d\d\d) /);
           return match ? match[1] : '';
       }
     });


### PR DESCRIPTION
``` javascript
new Date().toString()
"Sun Jun 01 2014 05:36:22 GMT+0200 (CEST)"
```

I forgot the `+` in the original timezone offset `%z` regex. This fixes the formatter and tests when run in Europe. I only had to fly across the world to find this bug :open_mouth:.
