### PR TITLE
Localize relative day of the week

### DIFF
--- a/time-elements.js
+++ b/time-elements.js
@@ -223,7 +223,13 @@
     } else if (daysPassed === 1) {
       return 'yesterday';
     } else {
-      return strftime(this.date, '%A');
+      if ('Intl' in window) {
+        var options = {weekday: 'long'};
+        var formatter = new window.Intl.DateTimeFormat(undefined, options);
+        return formatter.format(this.date);
+      } else {
+        return strftime(this.date, '%A');
+      }
     }
   };
 


### PR DESCRIPTION
We got some feedback via Halp about it being weird that some of the text is localized and some is now.

![screen shot 2014-06-04 at 11 23 18](https://cloud.githubusercontent.com/assets/137/3176570/6c8a6be8-ec06-11e3-8bcf-49dcc479e9c0.png)

This PR would fix the day of the week in that specific screenshot.

However, we still have some English strings here. I feel like we have to go all the way to make this right. Theres only a handful of strings that we'd need to translate that aren't baked into `Intl`.

Alternatively, we could say we only support **English**, but US or UK English. That'd allow us to be a little more European friendly while keeping the rest of the copy English.

Maybe we need some flags. `RelativeTimeElement.localize = false` `RelativeTimeElement.localize = ['en-us', 'en-gb']`. Something like that.

/cc @dgraham @dbussink 
