### PR TITLE
Always use english month names

### DIFF
--- a/time-elements.js
+++ b/time-elements.js
@@ -233,6 +233,10 @@
   //
   // Returns true if the day appears before the month.
   function isDayFirst() {
+    if (dayFirst !== null) {
+      return dayFirst;
+    }
+
     if (!('Intl' in window)) {
       return false;
     }
@@ -240,14 +244,21 @@
     var options = {day: 'numeric', month: 'short'};
     var formatter = new window.Intl.DateTimeFormat(undefined, options);
     var output = formatter.format(new Date(0));
-    return !!output.match(/^\d/);
+
+    dayFirst = !!output.match(/^\d/);
+    return dayFirst;
   }
+  var dayFirst = null;
 
   // Private: Determine if the year should be separated from the month and day
   // with a comma. For example, `9 Jun 2014` in en-GB and `Jun 9, 2014` in en-US.
   //
   // Returns true if the date needs a separator.
   function isYearSeparator() {
+    if (yearSeparator !== null) {
+      return yearSeparator;
+    }
+
     if (!('Intl' in window)) {
       return true;
     }
@@ -255,8 +266,11 @@
     var options = {day: 'numeric', month: 'short', year: 'numeric'};
     var formatter = new window.Intl.DateTimeFormat(undefined, options);
     var output = formatter.format(new Date(0));
-    return !!output.match(/\d,/);
+
+    yearSeparator = !!output.match(/\d,/);
+    return yearSeparator;
   }
+  var yearSeparator = null;
 
   RelativeTime.prototype.formatDate = function() {
     var format = isDayFirst() ? '%e %b' : '%b %e';


### PR DESCRIPTION
Using Intl.DateTimeFormat provides the month and day in the correct order according to the user's locale preferences. However, it also formats the month name in the locale's language.

So unless we can translate all text on the site into the locale's language, we need to use english month names. This prevents sentences from starting in english and finishing in a different language when it reaches a formatted date.

@dbussink @niik 
