### PR TITLE
Consistently use UTC dates.

### DIFF
--- a/time-elements.js
+++ b/time-elements.js
@@ -95,7 +95,7 @@
   }
 
   CalendarDate.fromDate = function(date) {
-    return new this(date.getFullYear(), date.getMonth() + 1, date.getDate());
+    return new this(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
   };
 
   CalendarDate.today = function() {


### PR DESCRIPTION
Fixes daysPassed() comparison that could allow `1 days ago` to display.

In this example, the UTC dates are only one day apart. However, because the first falls at 5:59 AM and my local timezone (Mountain) is UTC-0600, its local date is _two_ days away.

``` js
then = new Date('2014-06-23T05:59:59.117Z')
// => Sun Jun 22 2014 23:59:59 GMT-0600 (MDT)
now = new Date('2014-06-24T17:15:45.117Z')
// => Tue Jun 24 2014 11:15:45 GMT-0600 (MDT)

CalendarDate.fromDate(then).date
// => Sat Jun 21 2014 18:00:00 GMT-0600 (MDT)
CalendarDate.fromDate(now).date
// => Mon Jun 23 2014 18:00:00 GMT-0600 (MDT)
```

The `fromDate` factory method that converts a Date to CalendarDate just needs to use UTC to match the CalendarDate constructor.
