### PR TITLE
Use 'a day ago'.

### DIFF
--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -21,11 +21,11 @@ test('displays future times as just now', function() {
   equal(time.textContent, 'just now');
 });
 
-test('displays yesterday with time', function() {
+test('displays a day ago', function() {
   var now = new Date(Date.now() - 60 * 60 * 24 * 1000).toISOString();
   var time = document.createElement('time', 'relative-time');
   time.setAttribute('datetime', now);
-  ok(time.textContent.match(/yesterday at \d{1,2}:\d\d/));
+  equal(time.textContent, 'a day ago');
 });
 
 test('displays 2 days ago', function() {

--- a/time-elements.js
+++ b/time-elements.js
@@ -152,7 +152,6 @@
   };
 
   RelativeTime.prototype.timeElapsed = function() {
-    var weekday;
     var ms = new Date().getTime() - this.date.getTime();
     var sec = Math.round(ms / 1000);
     var min = Math.round(sec / 60);
@@ -172,8 +171,8 @@
       return 'an hour ago';
     } else if (hr < 24) {
       return hr + ' hours ago';
-    } else if (weekday = this.relativeWeekday()) {
-      return weekday + ' at ' + this.formatTime();
+    } else if (hr < 36) {
+      return 'a day ago';
     } else if (day < 30) {
       return day + ' days ago';
     } else {
@@ -215,17 +214,6 @@
         return 'a year ago';
     } else {
       return year + ' years ago';
-    }
-  };
-
-  RelativeTime.prototype.relativeWeekday = function() {
-    var daysPassed = this.calendarDate.daysPassed();
-    if (daysPassed === 0) {
-      return 'today';
-    } else if (daysPassed === 1) {
-      return 'yesterday';
-    } else {
-      return null;
     }
   };
 


### PR DESCRIPTION
Use "a day ago" rather than the problematic "yesterday at 4:53am" text. The logic was tough to get right, and seeing times from all over the world in my timezone from yesterday isn't all that helpful anyway.

This text matches what the `time-ago` element is already doing.
