### PR TITLE
Allow relative-time to handle future dates

### DIFF
--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -6,6 +6,7 @@
   <script src="../time-elements.js"></script>
 </head>
 <body>
+  <h2>Past Date</h2>
   <p>
     Local date:
     <time is="local-time" datetime="1970-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
@@ -44,6 +45,49 @@
   <p>
     Time ago (micro format):
     <time is="time-ago" format="micro" datetime="1970-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
+  </p>
+
+  <h2>Future Date</h2>
+  <p>
+    Local date:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Local time:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" hour="numeric" minute="2-digit" second="2-digit">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Local date and time:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric" hour="numeric" minute="2-digit" second="2-digit">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Relative time:
+    <time is="relative-time" datetime="2017-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
+  </p>
+
+  <p>
+    Time until:
+    <time is="time-until" datetime="2017-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
+  </p>
+
+  <p>
+    Time until (micro format):
+    <time is="time-until" format="micro" datetime="2017-01-01T00:00:00.000Z">
       Oops! This browser doesn't support Web Components.
     </time>
   </p>

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -7,7 +7,21 @@ test('rewrites from now past datetime to minutes ago', function() {
   equal(time.textContent, '3 minutes ago');
 });
 
+test('rewrites from now future datetime to minutes from now', function() {
+  var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '3 minutes from now');
+});
+
 test('rewrites a few seconds ago to just now', function() {
+  var now = new Date().toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('rewrites a few seconds from now to just now', function() {
   var now = new Date().toISOString();
   var time = document.createElement('time', 'relative-time');
   time.setAttribute('datetime', now);
@@ -28,6 +42,13 @@ test('displays a day ago', function() {
   equal(time.textContent, 'a day ago');
 });
 
+test('displays a day from now', function() {
+  var now = new Date(Date.now() + 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'a day from now');
+});
+
 test('displays 2 days ago', function() {
   var now = new Date(Date.now() - 2 * 60 * 60 * 24 * 1000).toISOString();
   var time = document.createElement('time', 'relative-time');
@@ -35,8 +56,22 @@ test('displays 2 days ago', function() {
   equal(time.textContent, '2 days ago');
 });
 
-test('switches to dates after 30 days', function() {
+test('displays 2 days from now', function() {
+  var now = new Date(Date.now() + 2 * 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '2 days from now');
+});
+
+test('switches to dates after 30 past days', function() {
   var now = new Date(Date.now() - 30 * 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  ok(time.textContent.match(/on \w\w\w \d{1,2}/));
+});
+
+test('switches to dates after 30 future days', function() {
+  var now = new Date(Date.now() + 30 * 60 * 60 * 24 * 1000).toISOString();
   var time = document.createElement('time', 'relative-time');
   time.setAttribute('datetime', now);
   ok(time.textContent.match(/on \w\w\w \d{1,2}/));

--- a/test/test.html
+++ b/test/test.html
@@ -31,6 +31,7 @@
   <script src="./local-time.js"></script>
   <script src="./relative-time.js"></script>
   <script src="./time-ago.js"></script>
+  <script src="./time-until.js"></script>
   <script src="./title-format.js"></script>
 </body>
 </html>

--- a/test/time-until.js
+++ b/test/time-until.js
@@ -1,0 +1,71 @@
+module('time-until');
+
+test('always uses relative dates', function() {
+  var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '10 years from now');
+});
+
+test('rewrites from now future datetime to minutes ago', function() {
+  var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '3 minutes from now');
+});
+
+test('rewrites a few seconds from now to just now', function() {
+  var now = new Date().toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('displays past times as just now', function() {
+  var now = new Date(Date.now() + 3 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('sets relative contents when parsed element is upgraded', function() {
+  var now = new Date().toISOString();
+  var root = document.createElement('div');
+  root.innerHTML = '<time is="time-until" datetime="'+now+'"></time>';
+  if ('CustomElements' in window) {
+    window.CustomElements.upgradeSubtree(root);
+  }
+  equal(root.children[0].textContent, 'just now');
+});
+
+test('micro formats years', function() {
+  var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '10y');
+});
+
+test('micro formats past times', function() {
+  var now = new Date(Date.now() + 3 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1m');
+});
+
+test('micro formats hours', function() {
+  var now = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1h');
+});
+
+test('micro formats days', function() {
+  var now = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1d');
+});

--- a/time-elements.js
+++ b/time-elements.js
@@ -202,30 +202,28 @@
     var day = Math.round(hr / 24);
     var month = Math.round(day / 30);
     var year = Math.round(month / 12);
-    if (month > 18) {
+    if (month >= 18) {
       return year + ' years from now';
-    } else if (month > 12) {
+    } else if (month >= 12) {
       return 'a year from now';
-    } else if (month > 2) {
+    } else if (day >= 45) {
       return month + ' months from now';
-    } else if (day > 45) {
+    } else if (day >= 30) {
       return 'a month from now';
-    } else if (day > 1) {
+    } else if (hr >= 36) {
       return day + ' days from now';
-    } else if (hr > 23) {
+    } else if (hr >= 24) {
       return 'a day from now';
-    } else if (hr > 2) {
+    } else if (min >= 90) {
       return hr + ' hours from now';
-    } else if (min > 45) {
+    } else if (min >= 45) {
       return 'an hour from now';
-    } else if (min > 2) {
+    } else if (sec >= 90) {
       return min + ' minutes from now';
-    } else if (sec > 90) {
+    } else if (sec >= 45) {
       return 'a minute from now';
-    } else if (sec > 45) {
+    } else if (sec >= 10) {
       return sec + ' seconds from now';
-    } else if (sec > 10) {
-      return 'just now';
     } else {
       return 'just now';
     } 
@@ -239,11 +237,11 @@
     var day = hr / 24;
     var month = day / 30;
     var year = month / 12;
-    if (day > 365) {
+    if (day >= 365) {
       return Math.round(year) + 'y';
-    } else if (hr > 24) {
+    } else if (hr >= 24) {
       return Math.round(day) + 'd';
-    } else if (min > 60) {
+    } else if (min >= 60) {
       return Math.round(hr) + 'h';
     } else if (min > 1) {
       return Math.round(min) + 'm';

--- a/time-elements.js
+++ b/time-elements.js
@@ -90,8 +90,11 @@
 
   RelativeTime.prototype.toString = function() {
     var ago = this.timeElapsed();
+    var ahead = this.timeAhead();
     if (ago) {
       return ago;
+    } else if (ahead) {
+      return ahead;
     } else {
       return 'on ' + this.formatDate();
     }
@@ -103,31 +106,34 @@
     var min = Math.round(sec / 60);
     var hr = Math.round(min / 60);
     var day = Math.round(hr / 24);
-    if (ms < 0) {
-      return 'just now';
-    } else if (sec < 10) {
-      return 'just now';
-    } else if (sec < 45) {
-      return sec + ' seconds ago';
-    } else if (sec < 90) {
-      return 'a minute ago';
-    } else if (min < 45) {
-      return min + ' minutes ago';
-    } else if (min < 90) {
-      return 'an hour ago';
-    } else if (hr < 24) {
-      return hr + ' hours ago';
-    } else if (hr < 36) {
-      return 'a day ago';
-    } else if (day < 30) {
-      return day + ' days ago';
-    } else {
+    if (ms >= 0 && day < 30) {
+      return this.timeAgoFromMs(ms);  
+    } 
+    else {
+      return null;
+    }
+  };
+
+  RelativeTime.prototype.timeAhead = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    if (ms >= 0 && day < 30) {
+      return this.timeUntil();  
+    } 
+    else {
       return null;
     }
   };
 
   RelativeTime.prototype.timeAgo = function() {
     var ms = new Date().getTime() - this.date.getTime();
+    return this.timeAgoFromMs(ms);
+  };
+
+  RelativeTime.prototype.timeAgoFromMs = function(ms) {
     var sec = Math.round(ms / 1000);
     var min = Math.round(sec / 60);
     var hr = Math.round(min / 60);
@@ -183,6 +189,68 @@
       return Math.round(year) + 'y';
     }
   };
+
+  RelativeTime.prototype.timeUntil = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    return this.timeUntilFromMs(ms);
+  };
+
+  RelativeTime.prototype.timeUntilFromMs = function(ms) {
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    var month = Math.round(day / 30);
+    var year = Math.round(month / 12);
+    if (month > 18) {
+      return year + ' years from now';
+    } else if (month > 12) {
+      return 'a year from now';
+    } else if (month > 2) {
+      return month + ' months from now';
+    } else if (day > 45) {
+      return 'a month from now';
+    } else if (day > 1) {
+      return day + ' days from now';
+    } else if (hr > 23) {
+      return 'a day from now';
+    } else if (hr > 2) {
+      return hr + ' hours from now';
+    } else if (min > 45) {
+      return 'an hour from now';
+    } else if (min > 2) {
+      return min + ' minutes from now';
+    } else if (sec > 90) {
+      return 'a minute from now';
+    } else if (sec > 45) {
+      return sec + ' seconds from now';
+    } else if (sec > 10) {
+      return 'just now';
+    } else {
+      return 'just now';
+    } 
+  };
+
+  RelativeTime.prototype.microTimeUntil = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    var sec = ms / 1000;
+    var min = sec / 60;
+    var hr = min / 60;
+    var day = hr / 24;
+    var month = day / 30;
+    var year = month / 12;
+    if (day > 365) {
+      return Math.round(year) + 'y';
+    } else if (hr > 24) {
+      return Math.round(day) + 'd';
+    } else if (min > 60) {
+      return Math.round(hr) + 'h';
+    } else if (min > 1) {
+      return Math.round(min) + 'm';
+    } else {
+      return '1m';
+    }
+  };  
 
   // Private: Determine if the day should be formatted before the month name in
   // the user's current locale. For example, `9 Jun` for en-GB and `Jun 9`
@@ -376,6 +444,18 @@
     }
   };
 
+  var TimeUntilPrototype = Object.create(RelativeTimePrototype);
+  TimeUntilPrototype.getFormattedDate = function() {
+    if (this._date) {
+      var format = this.getAttribute('format');
+      if (format === 'micro') {
+        return new RelativeTime(this._date).microTimeUntil();
+      } else {
+        return new RelativeTime(this._date).timeUntil();
+      }
+    }
+  };
+
 
   var LocalTimePrototype = Object.create(ExtendedTimePrototype);
 
@@ -509,6 +589,11 @@
 
   window.TimeAgoElement = document.registerElement('time-ago', {
     prototype: TimeAgoPrototype,
+    'extends': 'time'
+  });
+
+  window.TimeUntilElement = document.registerElement('time-until', {
+    prototype: TimeUntilPrototype,
     'extends': 'time'
   });
 

--- a/time-elements.js
+++ b/time-elements.js
@@ -90,13 +90,15 @@
 
   RelativeTime.prototype.toString = function() {
     var ago = this.timeElapsed();
-    var ahead = this.timeAhead();
     if (ago) {
       return ago;
-    } else if (ahead) {
-      return ahead;
     } else {
-      return 'on ' + this.formatDate();
+      var ahead = this.timeAhead();
+      if (ahead) {
+        return ahead;
+      } else {
+        return 'on ' + this.formatDate();
+      }
     }
   };
 


### PR DESCRIPTION
Why are we soooo concerned with the past? The future is where it's at!!! :rocket: :dizzy: 

We are looking at starting to use web components for travel applications and many of the dates and times associated are in the future. (I did find one lone place for future dates on GitHub, the milestone due date...so it at least has _some_ GH application.)

This PR adds relative-time results that are based off of the same time-ago intervals, just oriented towards the future. "3 days from now", "1 year from now", etc. It also adds a "time-until" option to counter "time-ago" in which the browser will ALWAYS give a future date.

There are several structural changes I made in able to do this so please take a look and provide any feedback.  

Open to any feedback, especially on the wordage...I went back and forth between "3 days from now" and "in 3 days"