### PR TITLE
Prepare for npm publish: add package.json fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
-  "private": true,
+  "name": "time-elements",
+  "version": "0.4.0",
+  "main": "time-elements.js",
   "devDependencies": {
     "bower": "1.3.8",
     "jshint": "2.5.2",


### PR DESCRIPTION
This removes the `"private": true` field and adds a main field so time elements can be used with just `require('time-elements')`. 

I'd love to see time-elements on npm :smile: 

Related but not coupled to this: CommonJS (or others for that matter) - the module currently doesn't export anything, since everything is mostly side-effect driven anyway. Maybe it could export the three constructors? Wondering what you think.