### PR TITLE
Future time redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Add a `<relative-time>` element to your markup. Provide a default formatted date
 
 Depending on how far in the future this is being viewed, the element's text will be replaced with one of the following formats:
 
+- 6 years from now
+- 20 days from now
+- 4 hours from now
+- 7 minutes from now
 - just now
 - 30 seconds ago
 - a minute ago
@@ -67,6 +71,25 @@ Depending on how far in the future this is being viewed, the element's text will
 - on Apr 1, 2014
 
 So, a relative date phrase is used for up to a month and then the actual date is shown.
+
+### time-until
+
+You can use `time-until` to always display a relative date that's in the future. It operates much like `<relative-time>`, except in the reverse, with past events shown as `just now` and future events always showing as relative:
+
+- 10 years from now
+- 20 days from now
+- 6 hours from now
+- 20 minutes from now
+- 30 seconds from now
+- just now
+
+Add a `<time-until>` element to your markup. Provide a default formatted date as the element's text content (e.g. April 1, 2024).
+
+``` html
+<time-until datetime="2024-04-01T16:30:00-08:00">
+  April 1, 2024
+</time-until>
+```
 
 ### time-ago
 

--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -52,42 +52,42 @@
   <h2>Future Date</h2>
   <p>
     Local date:
-    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
+    <local-time datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
       Jan 1 2017
-    </time>
+    </local-time>
   </p>
 
   <p>
     Local time:
-    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" hour="numeric" minute="2-digit" second="2-digit">
+    <local-time datetime="2017-01-01T00:00:00.000Z" hour="numeric" minute="2-digit" second="2-digit">
       Jan 1 2017
-    </time>
+    </local-time>
   </p>
 
   <p>
     Local date and time:
-    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric" hour="numeric" minute="2-digit" second="2-digit">
+    <local-time datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric" hour="numeric" minute="2-digit" second="2-digit">
       Jan 1 2017
-    </time>
+    </local-time>
   </p>
 
   <p>
     Relative time:
-    <time is="relative-time" datetime="2017-01-01T00:00:00.000Z">
+    <relative-time datetime="2017-01-01T00:00:00.000Z">
       Oops! This browser doesn't support Web Components.
-    </time>
+    </relative-time>
   </p>
 
   <p>
     Time until:
-    <time is="time-until" datetime="2017-01-01T00:00:00.000Z">
+    <time-until datetime="2017-01-01T00:00:00.000Z">
       Oops! This browser doesn't support Web Components.
-    </time>
+    </time-until>
   </p>
 
   <p>
     Time until (micro format):
-    <time is="time-until" format="micro" datetime="2017-01-01T00:00:00.000Z">
+    <time-until format="micro" datetime="2017-01-01T00:00:00.000Z">
       Oops! This browser doesn't support Web Components.
     </time>
   </p>

--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -6,6 +6,7 @@
   <script src="../time-elements.js"></script>
 </head>
 <body>
+  <h2>Past Date</h2>
   <p>
     Local date:
     <local-time datetime="1970-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
@@ -46,6 +47,49 @@
     <time-ago format="micro" datetime="1970-01-01T00:00:00.000Z">
       Oops! This browser doesn't support Web Components.
     </time-ago>
+  </p>
+
+  <h2>Future Date</h2>
+  <p>
+    Local date:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Local time:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" hour="numeric" minute="2-digit" second="2-digit">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Local date and time:
+    <time is="local-time" datetime="2017-01-01T00:00:00.000Z" weekday="short" year="numeric" month="short" day="numeric" hour="numeric" minute="2-digit" second="2-digit">
+      Jan 1 2017
+    </time>
+  </p>
+
+  <p>
+    Relative time:
+    <time is="relative-time" datetime="2017-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
+  </p>
+
+  <p>
+    Time until:
+    <time is="time-until" datetime="2017-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
+  </p>
+
+  <p>
+    Time until (micro format):
+    <time is="time-until" format="micro" datetime="2017-01-01T00:00:00.000Z">
+      Oops! This browser doesn't support Web Components.
+    </time>
   </p>
 </body>
 </html>

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -9,7 +9,7 @@ test('rewrites from now past datetime to minutes ago', function() {
 
 test('rewrites from now future datetime to minutes from now', function() {
   var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'relative-time');
+  var time = document.createElement('relative-time');
   time.setAttribute('datetime', now);
   equal(time.textContent, '3 minutes from now');
 });
@@ -23,7 +23,7 @@ test('rewrites a few seconds ago to just now', function() {
 
 test('rewrites a few seconds from now to just now', function() {
   var now = new Date().toISOString();
-  var time = document.createElement('time', 'relative-time');
+  var time = document.createElement('relative-time');
   time.setAttribute('datetime', now);
   equal(time.textContent, 'just now');
 });
@@ -44,7 +44,7 @@ test('displays a day ago', function() {
 
 test('displays a day from now', function() {
   var now = new Date(Date.now() + 60 * 60 * 24 * 1000).toISOString();
-  var time = document.createElement('time', 'relative-time');
+  var time = document.createElement('relative-time');
   time.setAttribute('datetime', now);
   equal(time.textContent, 'a day from now');
 });
@@ -58,7 +58,7 @@ test('displays 2 days ago', function() {
 
 test('displays 2 days from now', function() {
   var now = new Date(Date.now() + 2 * 60 * 60 * 24 * 1000).toISOString();
-  var time = document.createElement('time', 'relative-time');
+  var time = document.createElement('relative-time');
   time.setAttribute('datetime', now);
   equal(time.textContent, '2 days from now');
 });
@@ -72,7 +72,7 @@ test('switches to dates after 30 past days', function() {
 
 test('switches to dates after 30 future days', function() {
   var now = new Date(Date.now() + 30 * 60 * 60 * 24 * 1000).toISOString();
-  var time = document.createElement('time', 'relative-time');
+  var time = document.createElement('relative-time');
   time.setAttribute('datetime', now);
   ok(time.textContent.match(/on \w\w\w \d{1,2}/));
 });

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -7,9 +7,23 @@ test('rewrites from now past datetime to minutes ago', function() {
   equal(time.textContent, '3 minutes ago');
 });
 
+test('rewrites from now future datetime to minutes from now', function() {
+  var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '3 minutes from now');
+});
+
 test('rewrites a few seconds ago to just now', function() {
   var now = new Date().toISOString();
   var time = document.createElement('relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('rewrites a few seconds from now to just now', function() {
+  var now = new Date().toISOString();
+  var time = document.createElement('time', 'relative-time');
   time.setAttribute('datetime', now);
   equal(time.textContent, 'just now');
 });
@@ -28,6 +42,13 @@ test('displays a day ago', function() {
   equal(time.textContent, 'a day ago');
 });
 
+test('displays a day from now', function() {
+  var now = new Date(Date.now() + 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'a day from now');
+});
+
 test('displays 2 days ago', function() {
   var now = new Date(Date.now() - 2 * 60 * 60 * 24 * 1000).toISOString();
   var time = document.createElement('relative-time');
@@ -35,9 +56,23 @@ test('displays 2 days ago', function() {
   equal(time.textContent, '2 days ago');
 });
 
-test('switches to dates after 30 days', function() {
+test('displays 2 days from now', function() {
+  var now = new Date(Date.now() + 2 * 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '2 days from now');
+});
+
+test('switches to dates after 30 past days', function() {
   var now = new Date(Date.now() - 30 * 60 * 60 * 24 * 1000).toISOString();
   var time = document.createElement('relative-time');
+  time.setAttribute('datetime', now);
+  ok(time.textContent.match(/on \w\w\w \d{1,2}/));
+});
+
+test('switches to dates after 30 future days', function() {
+  var now = new Date(Date.now() + 30 * 60 * 60 * 24 * 1000).toISOString();
+  var time = document.createElement('time', 'relative-time');
   time.setAttribute('datetime', now);
   ok(time.textContent.match(/on \w\w\w \d{1,2}/));
 });

--- a/test/test.html
+++ b/test/test.html
@@ -31,6 +31,7 @@
   <script src="./local-time.js"></script>
   <script src="./relative-time.js"></script>
   <script src="./time-ago.js"></script>
+  <script src="./time-until.js"></script>
   <script src="./title-format.js"></script>
 </body>
 </html>

--- a/test/time-until.js
+++ b/test/time-until.js
@@ -1,0 +1,71 @@
+module('time-until');
+
+test('always uses relative dates', function() {
+  var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '10 years from now');
+});
+
+test('rewrites from now future datetime to minutes ago', function() {
+  var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, '3 minutes from now');
+});
+
+test('rewrites a few seconds from now to just now', function() {
+  var now = new Date().toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('displays past times as just now', function() {
+  var now = new Date(Date.now() + 3 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  equal(time.textContent, 'just now');
+});
+
+test('sets relative contents when parsed element is upgraded', function() {
+  var now = new Date().toISOString();
+  var root = document.createElement('div');
+  root.innerHTML = '<time is="time-until" datetime="'+now+'"></time>';
+  if ('CustomElements' in window) {
+    window.CustomElements.upgradeSubtree(root);
+  }
+  equal(root.children[0].textContent, 'just now');
+});
+
+test('micro formats years', function() {
+  var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '10y');
+});
+
+test('micro formats past times', function() {
+  var now = new Date(Date.now() + 3 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1m');
+});
+
+test('micro formats hours', function() {
+  var now = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1h');
+});
+
+test('micro formats days', function() {
+  var now = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
+  var time = document.createElement('time', 'time-until');
+  time.setAttribute('datetime', now);
+  time.setAttribute('format', 'micro');
+  equal(time.textContent, '1d');
+});

--- a/test/time-until.js
+++ b/test/time-until.js
@@ -2,28 +2,28 @@ module('time-until');
 
 test('always uses relative dates', function() {
   var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   equal(time.textContent, '10 years from now');
 });
 
 test('rewrites from now future datetime to minutes ago', function() {
   var now = new Date(Date.now() + 3 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   equal(time.textContent, '3 minutes from now');
 });
 
 test('rewrites a few seconds from now to just now', function() {
   var now = new Date().toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   equal(time.textContent, 'just now');
 });
 
 test('displays past times as just now', function() {
   var now = new Date(Date.now() + 3 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   equal(time.textContent, 'just now');
 });
@@ -31,7 +31,7 @@ test('displays past times as just now', function() {
 test('sets relative contents when parsed element is upgraded', function() {
   var now = new Date().toISOString();
   var root = document.createElement('div');
-  root.innerHTML = '<time is="time-until" datetime="'+now+'"></time>';
+  root.innerHTML = '<time-until datetime="'+now+'"></time-until>';
   if ('CustomElements' in window) {
     window.CustomElements.upgradeSubtree(root);
   }
@@ -40,7 +40,7 @@ test('sets relative contents when parsed element is upgraded', function() {
 
 test('micro formats years', function() {
   var now = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   time.setAttribute('format', 'micro');
   equal(time.textContent, '10y');
@@ -48,7 +48,7 @@ test('micro formats years', function() {
 
 test('micro formats past times', function() {
   var now = new Date(Date.now() + 3 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   time.setAttribute('format', 'micro');
   equal(time.textContent, '1m');
@@ -56,7 +56,7 @@ test('micro formats past times', function() {
 
 test('micro formats hours', function() {
   var now = new Date(Date.now() + 60 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   time.setAttribute('format', 'micro');
   equal(time.textContent, '1h');
@@ -64,7 +64,7 @@ test('micro formats hours', function() {
 
 test('micro formats days', function() {
   var now = new Date(Date.now() + 25 * 60 * 60 * 1000).toISOString();
-  var time = document.createElement('time', 'time-until');
+  var time = document.createElement('time-until');
   time.setAttribute('datetime', now);
   time.setAttribute('format', 'micro');
   equal(time.textContent, '1d');

--- a/time-elements.js
+++ b/time-elements.js
@@ -173,22 +173,22 @@
 
   RelativeTime.prototype.microTimeAgo = function() {
     var ms = new Date().getTime() - this.date.getTime();
-    var sec = ms / 1000;
-    var min = sec / 60;
-    var hr = min / 60;
-    var day = hr / 24;
-    var month = day / 30;
-    var year = month / 12;
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    var month = Math.round(day / 30);
+    var year = Math.round(month / 12);
     if (min < 1) {
       return '1m';
     } else if (min < 60) {
-      return Math.round(min) + 'm';
+      return min + 'm';
     } else if (hr < 24) {
-      return Math.round(hr) + 'h';
+      return hr + 'h';
     } else if (day < 365) {
-      return Math.round(day) + 'd';
+      return day + 'd';
     } else {
-      return Math.round(year) + 'y';
+      return year + 'y';
     }
   };
 
@@ -233,20 +233,20 @@
 
   RelativeTime.prototype.microTimeUntil = function() {
     var ms = this.date.getTime() - (new Date().getTime());
-    var sec = ms / 1000;
-    var min = sec / 60;
-    var hr = min / 60;
-    var day = hr / 24;
-    var month = day / 30;
-    var year = month / 12;
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    var month = Math.round(day / 30);
+    var year = Math.round(month / 12);
     if (day >= 365) {
-      return Math.round(year) + 'y';
+      return year + 'y';
     } else if (hr >= 24) {
-      return Math.round(day) + 'd';
+      return day + 'd';
     } else if (min >= 60) {
-      return Math.round(hr) + 'h';
+      return hr + 'h';
     } else if (min > 1) {
-      return Math.round(min) + 'm';
+      return min + 'm';
     } else {
       return '1m';
     }

--- a/time-elements.js
+++ b/time-elements.js
@@ -109,8 +109,8 @@
     var hr = Math.round(min / 60);
     var day = Math.round(hr / 24);
     if (ms >= 0 && day < 30) {
-      return this.timeAgoFromMs(ms);  
-    } 
+      return this.timeAgoFromMs(ms);
+    }
     else {
       return null;
     }
@@ -123,8 +123,8 @@
     var hr = Math.round(min / 60);
     var day = Math.round(hr / 24);
     if (ms >= 0 && day < 30) {
-      return this.timeUntil();  
-    } 
+      return this.timeUntil();
+    }
     else {
       return null;
     }
@@ -228,7 +228,7 @@
       return sec + ' seconds from now';
     } else {
       return 'just now';
-    } 
+    }
   };
 
   RelativeTime.prototype.microTimeUntil = function() {
@@ -250,7 +250,7 @@
     } else {
       return '1m';
     }
-  };  
+  };
 
   // Private: Determine if the day should be formatted before the month name in
   // the user's current locale. For example, `9 Jun` for en-GB and `Jun 9`
@@ -586,8 +586,7 @@
   });
 
   window.TimeUntilElement = document.registerElement('time-until', {
-    prototype: TimeUntilPrototype,
-    'extends': 'time'
+    prototype: TimeUntilPrototype
   });
 
   // Public: LocalTimeElement constructor.

--- a/time-elements.js
+++ b/time-elements.js
@@ -93,7 +93,12 @@
     if (ago) {
       return ago;
     } else {
-      return 'on ' + this.formatDate();
+      var ahead = this.timeAhead();
+      if (ahead) {
+        return ahead;
+      } else {
+        return 'on ' + this.formatDate();
+      }
     }
   };
 
@@ -103,31 +108,34 @@
     var min = Math.round(sec / 60);
     var hr = Math.round(min / 60);
     var day = Math.round(hr / 24);
-    if (ms < 0) {
-      return 'just now';
-    } else if (sec < 10) {
-      return 'just now';
-    } else if (sec < 45) {
-      return sec + ' seconds ago';
-    } else if (sec < 90) {
-      return 'a minute ago';
-    } else if (min < 45) {
-      return min + ' minutes ago';
-    } else if (min < 90) {
-      return 'an hour ago';
-    } else if (hr < 24) {
-      return hr + ' hours ago';
-    } else if (hr < 36) {
-      return 'a day ago';
-    } else if (day < 30) {
-      return day + ' days ago';
-    } else {
+    if (ms >= 0 && day < 30) {
+      return this.timeAgoFromMs(ms);  
+    } 
+    else {
+      return null;
+    }
+  };
+
+  RelativeTime.prototype.timeAhead = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    if (ms >= 0 && day < 30) {
+      return this.timeUntil();  
+    } 
+    else {
       return null;
     }
   };
 
   RelativeTime.prototype.timeAgo = function() {
     var ms = new Date().getTime() - this.date.getTime();
+    return this.timeAgoFromMs(ms);
+  };
+
+  RelativeTime.prototype.timeAgoFromMs = function(ms) {
     var sec = Math.round(ms / 1000);
     var min = Math.round(sec / 60);
     var hr = Math.round(min / 60);
@@ -183,6 +191,66 @@
       return Math.round(year) + 'y';
     }
   };
+
+  RelativeTime.prototype.timeUntil = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    return this.timeUntilFromMs(ms);
+  };
+
+  RelativeTime.prototype.timeUntilFromMs = function(ms) {
+    var sec = Math.round(ms / 1000);
+    var min = Math.round(sec / 60);
+    var hr = Math.round(min / 60);
+    var day = Math.round(hr / 24);
+    var month = Math.round(day / 30);
+    var year = Math.round(month / 12);
+    if (month >= 18) {
+      return year + ' years from now';
+    } else if (month >= 12) {
+      return 'a year from now';
+    } else if (day >= 45) {
+      return month + ' months from now';
+    } else if (day >= 30) {
+      return 'a month from now';
+    } else if (hr >= 36) {
+      return day + ' days from now';
+    } else if (hr >= 24) {
+      return 'a day from now';
+    } else if (min >= 90) {
+      return hr + ' hours from now';
+    } else if (min >= 45) {
+      return 'an hour from now';
+    } else if (sec >= 90) {
+      return min + ' minutes from now';
+    } else if (sec >= 45) {
+      return 'a minute from now';
+    } else if (sec >= 10) {
+      return sec + ' seconds from now';
+    } else {
+      return 'just now';
+    } 
+  };
+
+  RelativeTime.prototype.microTimeUntil = function() {
+    var ms = this.date.getTime() - (new Date().getTime());
+    var sec = ms / 1000;
+    var min = sec / 60;
+    var hr = min / 60;
+    var day = hr / 24;
+    var month = day / 30;
+    var year = month / 12;
+    if (day >= 365) {
+      return Math.round(year) + 'y';
+    } else if (hr >= 24) {
+      return Math.round(day) + 'd';
+    } else if (min >= 60) {
+      return Math.round(hr) + 'h';
+    } else if (min > 1) {
+      return Math.round(min) + 'm';
+    } else {
+      return '1m';
+    }
+  };  
 
   // Private: Determine if the day should be formatted before the month name in
   // the user's current locale. For example, `9 Jun` for en-GB and `Jun 9`
@@ -371,6 +439,18 @@
     }
   };
 
+  var TimeUntilPrototype = Object.create(RelativeTimePrototype);
+  TimeUntilPrototype.getFormattedDate = function() {
+    if (this._date) {
+      var format = this.getAttribute('format');
+      if (format === 'micro') {
+        return new RelativeTime(this._date).microTimeUntil();
+      } else {
+        return new RelativeTime(this._date).timeUntil();
+      }
+    }
+  };
+
 
   var LocalTimePrototype = Object.create(ExtendedTimePrototype);
 
@@ -503,6 +583,11 @@
 
   window.TimeAgoElement = document.registerElement('time-ago', {
     prototype: TimeAgoPrototype
+  });
+
+  window.TimeUntilElement = document.registerElement('time-until', {
+    prototype: TimeUntilPrototype,
+    'extends': 'time'
   });
 
   // Public: LocalTimeElement constructor.


### PR DESCRIPTION
This is a continuation of @markmcspadden's excellent pull from a year and a half ago: #42 (which is also related to #38).

Basically, time-elements should support future dates too. I'm living in the future so the present is my past, time-elements is a present, merge if tests pass (they do).

The majority of this is pulled from @markmcspadden's work; I just updated the syntax from the deprecated `<time is="local-time">` form and updated the README.

This pull adds an additional `time-until` element (which we can axe if it's not worthwhile), and it updates `relative-time` to see the future, too.

/cc @josh @dgraham @github/techno

