### PR TITLE
Use phantomjs-prebuilt

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-phantomjs/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: node_js
 node_js: 6.9.1 # latest LTS
+cache:
+  directories:
+    - node_modules/phantomjs-prebuilt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,2 @@
 language: node_js
 node_js: 6.9.1 # latest LTS
-cache:
-  directories:
-    - phantomjs

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REPORTER = $(if $(CI),spec,dot)
 build: node_modules/
 
 test: node_modules/ build lint
-	phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
+	./node_modules/phantomjs-prebuilt/bin/phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
 		./test/test.html $(REPORTER) '{"useColors":true}'
 
 lint: node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 REPORTER = $(if $(CI),spec,dot)
 
-ifeq ($(TRAVIS),)
 build: node_modules/
-else
-PATH := $(PWD)/phantomjs/bin:$(PATH)
-build: node_modules/ phantomjs/bin/phantomjs
-endif
 
 test: node_modules/ build lint
 	phantomjs ./node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
@@ -17,12 +12,7 @@ lint: node_modules/
 node_modules/:
 	npm install
 
-phantomjs/bin/phantomjs:
-	mkdir -p phantomjs
-	wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O- | \
-		tar xj -C phantomjs --strip-components 1
-
 clean:
-	rm -rf ./node_modules phantomjs
+	rm -rf ./node_modules
 
 .PHONY: build clean lint test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "eslint-plugin-github": "^0.6.1",
     "mocha": "^3.1.2",
     "mocha-phantomjs-core": "^2.1.0",
+    "phantomjs-prebuilt": "^2.1.13",
     "webcomponents.js": "^0.7.23"
   }
 }


### PR DESCRIPTION
Switches custom phantomjs fetching code to caching the npm phantomjs-prebuilt package.

* Sets up phantomjs binary locally on macOS when missing. For an example, I don't have phantomjs installed via homebrew.
* Ensures consistent phantomjs version locally and in CI.
* Less code.

Speed seems uneffected.

**master**

`npm install` (w/o phantomjs-prebuilt package) 12.44s

**phantomjs-cache**

Uncached `npm install` 21.85s
Cached `npm install`13.23s

##

CC: @mislav 