### PR TITLE
v1 fixes

### DIFF
--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.23/webcomponents.min.js"></script>
-  <script src="../dist/time-elements-legacy.js"></script>
 </head>
 <body>
   <h2>Past Date</h2>
@@ -91,5 +90,6 @@
       Oops! This browser doesn't support Web Components.
     </time>
   </p>
+  <script src="../dist/time-elements-legacy.js"></script>
 </body>
 </html>

--- a/src/extended-time-element.js
+++ b/src/extended-time-element.js
@@ -15,7 +15,7 @@ export default class ExtendedTimeElement extends HTMLElement {
     }
 
     const title = this.getFormattedTitle()
-    if (title) {
+    if (title && !this.hasAttribute('title')) {
       this.setAttribute('title', title)
     }
 
@@ -33,10 +33,6 @@ export default class ExtendedTimeElement extends HTMLElement {
   getFormattedTitle() {
     if (!this._date) {
       return
-    }
-
-    if (this.hasAttribute('title')) {
-      return this.getAttribute('title')
     }
 
     const formatter = makeFormatter({

--- a/src/relative-time-element.js
+++ b/src/relative-time-element.js
@@ -8,7 +8,7 @@ export default class RelativeTimeElement extends ExtendedTimeElement {
     }
   }
 
-  attachedCallback() {
+  connectedCallback() {
     nowElements.push(this)
 
     if (!updateNowElementsId) {
@@ -17,7 +17,7 @@ export default class RelativeTimeElement extends ExtendedTimeElement {
     }
   }
 
-  detachedCallback() {
+  disconnectedCallback() {
     const ix = nowElements.indexOf(this)
     if (ix !== -1) {
       nowElements.splice(ix, 1)


### PR DESCRIPTION
For #67. @josh I made 2 fixes here:

1. Update callback names
2. Define custom elements after use, in `polymer.html`. More on this 👇🏻

This is a super weird Chrome bug that took away hours of my life 😭. While testing I noticed that it looks broken:

<img width="400" src="https://user-images.githubusercontent.com/1153134/34195599-69117156-e599-11e7-8813-a09a65b6e238.png">

It doesn't happen in Safari. Turns out a bug has been filed: https://bugs.chromium.org/p/chromium/issues/detail?id=739417 Here's another test case I made: http://jsbin.com/xizojipoji/1/edit?html,output It seems like the original `textContent` gets appended late when element is defined **before** use, so it can't be cleared/replaced because it didn't exist.

cc @dgraham cause we talked about this.

---

Anyways all looks good now I think! :sparkles: 

Do you know if there's an efficient way to test the `setInterval` update for `relative-time`? The broken callbacks didn't get caught by the test.