### PR TITLE
Making sure example works in old Safari and IE 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Attribute      | Options                        | Description
 
 - Chrome
 - Firefox
-- Safari 6.1+
-- Internet Explorer 9+
+- Safari 9.1+
+- Internet Explorer 11+
 - Microsoft Edge
 
 ## See Also

--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -2,7 +2,9 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.7.23/webcomponents.min.js"></script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.34.2/es6-shim.min.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/@webcomponents/webcomponents-platform@1.0.0/webcomponents-platform.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.22/webcomponents-lite.js"></script>
 </head>
 <body>
   <h2>Past Date</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -542,6 +542,15 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-plugin-transform-custom-element-classes": "^0.1.0",
     "babel-plugin-transform-es2015-block-scoping": "^6.18.0",
     "babel-plugin-transform-es2015-classes": "^6.18.0",
+    "babel-plugin-transform-es2015-template-literals": "^6.22.0",
     "chai": "^3.5.0",
     "eslint": "^4.13.1",
     "eslint-plugin-github": "^0.20.0",

--- a/rollup.legacy-config.js
+++ b/rollup.legacy-config.js
@@ -7,6 +7,7 @@ export default {
   plugins: [
     babel({
       plugins: [
+        'transform-es2015-template-literals',
         'transform-custom-element-classes',
         'transform-es2015-block-scoping',
         'transform-es2015-classes'


### PR DESCRIPTION
- Add required polyfills
- Build with template literal transformation
- Update readme for browser support (matches https://github.com/webcomponents/webcomponentsjs#browser-support)
