### PR TITLE
Update polyfill requirement and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ This component is built on the upcoming [Web Component](http://webcomponents.org
 
 You'll need to use a polyfill to get this feature today. Either the [Polymer](http://www.polymer-project.org/) or [X-Tag](http://www.x-tags.org/) frameworks supply a polyfill, or you can install the standalone [CustomElements](https://github.com/webcomponents/webcomponentsjs) polyfill.
 
+Legacy browsers require other generic polyfills. See `examples/polymer.html` for details.
+
 ``` html
-<script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/0.5.4/CustomElements.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.22/webcomponents-hi-ce.js"></script>
 ```
 
 ## Usage

--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -2,9 +2,14 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <!-- For Reflect.construct -->
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/es6-shim/0.34.2/es6-shim.min.js"></script>
+  <!-- For CustomEvent -->
   <script type="text/javascript" src="https://unpkg.com/@webcomponents/webcomponents-platform@1.0.0/webcomponents-platform.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.22/webcomponents-lite.js"></script>
+  <!-- For Template -->
+  <script type="text/javascript" src="https://unpkg.com/@webcomponents/template@1.2.2/template.js"></script>
+  <!-- For HTML Imports and Custom Elements -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.22/webcomponents-hi-ce.js"></script>
 </head>
 <body>
   <h2>Past Date</h2>


### PR DESCRIPTION
1. Change `webcomponent-lite.js` to `webcomponent-hi-ce.js` because we don't need Shady DOM/CSS. [The differences](https://github.com/webcomponents/webcomponentsjs/tree/068cfc9068cedf2876a5363cdfd4912cc3801bd4#how-to-use).

2. Individually include the polyfills that used to come with `webcomponents-lite.js`.

I think we are ready for v1! Yeah?