### PR TITLE
🔍check if `<local-time />` is defined before registering

### DIFF
--- a/src/local-time-element.js
+++ b/src/local-time-element.js
@@ -119,5 +119,7 @@ function formatTime(el) {
 //   var time = new LocalTimeElement()
 //   # => <local-time></local-time>
 //
-window.LocalTimeElement = LocalTimeElement
-window.customElements.define('local-time', LocalTimeElement)
+if (!window.customElements.get('local-time')) {
+  window.LocalTimeElement = LocalTimeElement
+  window.customElements.define('local-time', LocalTimeElement)
+}


### PR DESCRIPTION
This patch checks if a `<local-time />` element already exists before we register it on the page and only registers the element if there isn't one already registered.