### PR TITLE
Expose faux private field 

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,6 +2,7 @@
 
 declare module 'time-elements' {
   declare class ExtendedTimeElement extends HTMLElement {
+    _date: ?Date;
     getFormattedTitle(): ?string;
     getFormattedDate(): ?string;
   }


### PR DESCRIPTION
At github we are trying to extend one of the elements and using it in application code but flow keeps complaining that `_date` isn't defined on the element since we decided not to ship it with the flow definitions

This PR adds the property back in so we can access it and unblock the PR.

Ref: https://github.com/github/time-elements/pull/106#discussion_r283850992
Ref: https://github.com/github/github/pull/115283#issuecomment-492978635