### PR TITLE
Make sure to format months ago correctly

### DIFF
--- a/src/relative-time.js
+++ b/src/relative-time.js
@@ -81,7 +81,7 @@ export default class RelativeTime {
       return formatRelativeTime(this.locale, -day, 'day')
     } else if (day < 30) {
       return formatRelativeTime(this.locale, -day, 'day')
-    } else if (day < 45) {
+    } else if (month < 12) {
       return formatRelativeTime(this.locale, -month, 'month')
     } else if (month < 18) {
       return formatRelativeTime(this.locale, -year, 'year')

--- a/test/time-ago.js
+++ b/test/time-ago.js
@@ -37,6 +37,20 @@ suite('time-ago', function() {
     assert.equal(root.children[0].textContent, 'now')
   })
 
+  test('rewrites from now past datetime to months ago', function() {
+    const now = new Date(Date.now() - 3 * 30 * 24 * 60 * 60 * 1000).toISOString()
+    const time = document.createElement('time-ago')
+    time.setAttribute('datetime', now)
+    assert.equal(time.textContent, '3 months ago')
+  })
+
+  test('rewrites from now past datetime to years ago', function() {
+    const now = new Date(Date.now() - 12 * 30 * 24 * 60 * 60 * 1000).toISOString()
+    const time = document.createElement('time-ago')
+    time.setAttribute('datetime', now)
+    assert.equal(time.textContent, 'last year')
+  })
+
   test('micro formats years', function() {
     const now = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
     const time = document.createElement('time-ago')


### PR DESCRIPTION
I think we were erronusly only displaying "x months ago" when the time elapsed was 31-45 days. This patch makes sure we are showing "x months ago" when the time elapsed is 31days - 11 months.

Fixes: #113