### PR TITLE
Rename package to include the @github scope.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "time-elements",
+  "name": "@github/time-elements",
   "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "time-elements",
+  "name": "@github/time-elements",
   "version": "3.0.0",
   "main": "dist/time-elements-legacy.js",
   "module": "dist/time-elements.js",


### PR DESCRIPTION
I think we want to publish a non beta version 3.0.0 before merging this and then we can follow the normal playbook of:

- Bumping the patch version.
- Publishing to npm.
- Deprecate the package without the scope with a message pointing to new package name.

Ref: https://github.com/github/web-systems/issues/216