### PR TITLE
RelativeTime: Support custom format

### DIFF
--- a/examples/polymer.html
+++ b/examples/polymer.html
@@ -79,7 +79,7 @@
 
   <p>
     Relative time:
-    <relative-time datetime="2017-01-01T00:00:00.000Z">
+    <relative-time datetime="2017-01-01T00:00:00.000Z" format="%Y-%m-%d">
       Oops! This browser doesn't support Web Components.
     </relative-time>
   </p>

--- a/src/relative-time-element.js
+++ b/src/relative-time-element.js
@@ -8,7 +8,7 @@ export default class RelativeTimeElement extends ExtendedTimeElement {
   getFormattedDate(): ?string {
     const date = this.date
     if (date) {
-      return new RelativeTime(date, localeFromElement(this)).toString()
+      return new RelativeTime(date, localeFromElement(this)).toString(this.getAttribute('format'))
     }
   }
 

--- a/src/relative-time.js
+++ b/src/relative-time.js
@@ -11,18 +11,19 @@ export default class RelativeTime {
     this.locale = locale
   }
 
-  toString() {
+  toString(format: ?string) {
     const ago = this.timeElapsed()
     if (ago) {
       return ago
-    } else {
-      const ahead = this.timeAhead()
-      if (ahead) {
-        return ahead
-      } else {
-        return `on ${this.formatDate()}`
-      }
     }
+    const ahead = this.timeAhead()
+    if (ahead) {
+      return ahead
+    }
+    if (format) {
+      return this.formatDate(format)
+    }
+    return `on ${this.formatDate()}`
   }
 
   timeElapsed() {
@@ -171,10 +172,13 @@ export default class RelativeTime {
     }
   }
 
-  formatDate() {
-    let format = isDayFirst() ? '%e %b' : '%b %e'
-    if (!isThisYear(this.date)) {
-      format += isYearSeparator() ? ', %Y' : ' %Y'
+  formatDate(defaultFormat: ?string) {
+    let format = defaultFormat
+    if (format == null) {
+      format = isDayFirst() ? '%e %b' : '%b %e'
+      if (!isThisYear(this.date)) {
+        format += isYearSeparator() ? ', %Y' : ' %Y'
+      }
     }
     return strftime(this.date, format)
   }


### PR DESCRIPTION
Allow user to supply a strftime() format through the format
attribute, to be used when outside the relative time scope.