### PR TITLE
Add TS window declaration for Time Elements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,3 +19,12 @@ export class TimeAgoElement extends ExtendedTimeElement {
 export class TimeUntilElement extends ExtendedTimeElement {
   getFormattedDate(): string | undefined
 }
+
+declare global {
+  interface Window {
+    LocalTimeElement: typeof LocalTimeElement;
+    RelativeTimeElement: typeof RelativeTimeElement;
+    TimeAgoElement: typeof TimeAgoElement;
+    TimeUntilElement: typeof TimeUntilElement;
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignments to Window.

This PR adds the declaration of `LocalTimeElement`, `RelativeTimeElement`, `TimeAgoElement`, and `TimeUntilElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58