### PR TITLE
Changes to last year format

### DIFF
--- a/src/relative-time.js
+++ b/src/relative-time.js
@@ -81,10 +81,8 @@ export default class RelativeTime {
       return formatRelativeTime(this.locale, -day, 'day')
     } else if (day < 30) {
       return formatRelativeTime(this.locale, -day, 'day')
-    } else if (month < 12) {
-      return formatRelativeTime(this.locale, -month, 'month')
     } else if (month < 18) {
-      return formatRelativeTime(this.locale, -year, 'year')
+      return formatRelativeTime(this.locale, -month, 'month')
     } else {
       return formatRelativeTime(this.locale, -year, 'year')
     }

--- a/test/time-ago.js
+++ b/test/time-ago.js
@@ -1,4 +1,19 @@
 suite('time-ago', function() {
+  let dateNow
+
+  function freezeTime(date) {
+    dateNow = Date.now
+    Date.now = function() {
+      return date
+    }
+  }
+
+  teardown(function() {
+    if (dateNow) {
+      Date.now = dateNow
+    }
+  })
+
   test('always uses relative dates', function() {
     const now = new Date(Date.now() - 10 * 365 * 24 * 60 * 60 * 1000).toISOString()
     const time = document.createElement('time-ago')

--- a/test/time-ago.js
+++ b/test/time-ago.js
@@ -59,11 +59,20 @@ suite('time-ago', function() {
     assert.equal(time.textContent, '3 months ago')
   })
 
-  test('rewrites from now past datetime to years ago', function() {
-    const now = new Date(Date.now() - 12 * 30 * 24 * 60 * 60 * 1000).toISOString()
-    const time = document.createElement('time-ago')
-    time.setAttribute('datetime', now)
-    assert.equal(time.textContent, 'last year')
+  test('rewrites time-ago datetimes < 18months as "months ago"', function() {
+    freezeTime(new Date(2020, 0, 1))
+    const then = new Date(2018, 10, 1).toISOString()
+    const timeElement = document.createElement('time-ago')
+    timeElement.setAttribute('datetime', then)
+    assert.equal(timeElement.textContent, '15 months ago')
+  })
+
+  test('rewrites time-ago datetimes >= 18 months as "years ago"', function() {
+    freezeTime(new Date(2020, 0, 1))
+    const then = new Date(2018, 6, 1).toISOString()
+    const timeElement = document.createElement('time-ago')
+    timeElement.setAttribute('datetime', then)
+    assert.equal(timeElement.textContent, '2 years ago')
   })
 
   test('micro formats years', function() {


### PR DESCRIPTION
This change increases the month cutoff from 12 to 18 months meaning that months > 12 < 18 will be displayed as `'x months ago'` instead  of `'last year'`. Months >18 will be displayed as `'x years ago'`.

This is to prevent `'last year'` showing up in January 2020 and you are viewing a `<time-ago>` element set to November 2018. Since it's more than 12 months we'll round it down to 1 year, parse it as a years ago and `Intl.RelativeTimeFormat` will format it as `'last year'`.

Ref: https://github.com/github/github/issues/132315