### PR TITLE
Fix bad mock

### DIFF
--- a/test/time-ago.js
+++ b/test/time-ago.js
@@ -75,7 +75,7 @@ suite('time-ago', function() {
 
   test('rewrites time-ago datetimes < 18months as "months ago"', function() {
     freezeTime(new Date(2020, 0, 1))
-    const then = new Date(2018, 10, 1).toISOString()
+    const then = new Date(2018, 9, 1).toISOString()
     const timeElement = document.createElement('time-ago')
     timeElement.setAttribute('datetime', then)
     assert.equal(timeElement.textContent, '15 months ago')

--- a/test/time-ago.js
+++ b/test/time-ago.js
@@ -1,16 +1,30 @@
 suite('time-ago', function() {
   let dateNow
 
-  function freezeTime(date) {
-    dateNow = Date.now
-    Date.now = function() {
-      return date
+  function freezeTime(expected) {
+    dateNow = Date
+
+    function MockDate(...args) {
+      if (args.length) {
+        return new dateNow(...args)
+      }
+      return new dateNow(expected)
     }
+
+    MockDate.UTC = dateNow.UTC
+    MockDate.parse = dateNow.parse
+    MockDate.now = () => expected.getTime()
+    MockDate.prototype = dateNow.prototype
+
+    // eslint-disable-next-line no-global-assign
+    Date = MockDate
   }
 
   teardown(function() {
     if (dateNow) {
-      Date.now = dateNow
+      // eslint-disable-next-line no-global-assign
+      Date = dateNow
+      dateNow = null
     }
   })
 


### PR DESCRIPTION
In #133 I made changes that were backed up by tests. Those tests relied on a mock of `Date` which did not work. The tests only ran green because I made the oversight of using current dates as the freeze date. Now that some time has passed, the tests are failing on `master` and this was discovered by @muan in #138.

This change changes the mock to _actually_ freeze the time and fixes a off by one error in the tests.