### PR TITLE
refactor: simplify nowelements tracking with a set

### DIFF
--- a/src/relative-time-element.js
+++ b/src/relative-time-element.js
@@ -29,7 +29,7 @@ export default class RelativeTimeElement extends ExtendedTimeElement {
 
   connectedCallback() {
     nowElements.add(this)
-    updateNowElements()
+    if (!updateNowElementsId) updateNowElements()
     super.connectedCallback()
   }
 

--- a/src/relative-time-element.js
+++ b/src/relative-time-element.js
@@ -34,7 +34,7 @@ export default class RelativeTimeElement extends ExtendedTimeElement {
   }
 
   disconnectedCallback() {
-    nowElements.remove(this)
+    nowElements.delete(this)
   }
 }
 


### PR DESCRIPTION
The tracking for elements which need to be updated to change to `now` is a little more complex than it needs to be with modern JS. It's also the suspect in a memory leak we have for long running tabs.

My theory is a `connectedCallback` is fired twice as an element moves in the DOM, and the array gets populated. The array is `spliced` with an `indexOf` check, so if duplicates are in the array it will not clean them up, causing a memory leak.

The "solution" could be to do a `while(nowElements.includes(this))`... or just use a `Set` :laughing:.

This changes the code to use a `Set`, it also reconfigures the timeout code to ensure we avoid `setInterval` which can cause queueing issues, and only dispatch a `setTimeout` in the `updateNowElements` call. This simplifies the logic quite a bit.