### PR TITLE
Observe time zone name attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc && rollup -c",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
-    "test": "karma start ./test/karma.config.cjs",
+    "test": "TZ=Asia/Dubai karma start ./test/karma.config.cjs",
     "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'"
   },
   "prettier": "@github/prettier-config",

--- a/src/extended-time-element.ts
+++ b/src/extended-time-element.ts
@@ -4,7 +4,20 @@ const datetimes = new WeakMap()
 
 export default class ExtendedTimeElement extends HTMLElement {
   static get observedAttributes(): string[] {
-    return ['datetime', 'day', 'format', 'lang', 'hour', 'minute', 'month', 'second', 'title', 'weekday', 'year']
+    return [
+      'datetime',
+      'day',
+      'format',
+      'lang',
+      'hour',
+      'minute',
+      'month',
+      'second',
+      'title',
+      'weekday',
+      'year',
+      'time-zone-name'
+    ]
   }
 
   connectedCallback(): void {

--- a/test/local-time.js
+++ b/test/local-time.js
@@ -1,4 +1,14 @@
 suite('local-time', function () {
+  let fixture
+  suiteSetup(() => {
+    fixture = document.createElement('div')
+    document.body.appendChild(fixture)
+  })
+
+  teardown(() => {
+    fixture.innerHTML = ''
+  })
+
   test('null getFormattedDate when datetime missing', function () {
     const time = document.createElement('local-time')
     time.setAttribute('format', '%Y-%m-%dT%H:%M:%SZ')
@@ -85,5 +95,19 @@ suite('local-time', function () {
       window.CustomElements.upgradeSubtree(root)
     }
     assert.match(root.children[0].textContent, /^\d{1,2} (\w+([+-]\d+)?)$/)
+    assert.equal(root.children[0].textContent, '0 GMT+1')
+  })
+
+  test('updates time zone when the `time-zone-name` attribute changes', function () {
+    const el = document.createElement('local-time')
+    el.setAttribute('datetime', '1970-01-01T00:00:00.000-08:00')
+    el.setAttribute('time-zone-name', 'short')
+
+    fixture.appendChild(el)
+    assert.equal(el.textContent, '1/1/1970, GMT+1')
+
+    el.setAttribute('time-zone-name', 'long')
+
+    assert.equal(el.textContent, '1/1/1970, GMT+01:00')
   })
 })

--- a/test/local-time.js
+++ b/test/local-time.js
@@ -95,7 +95,7 @@ suite('local-time', function () {
       window.CustomElements.upgradeSubtree(root)
     }
     assert.match(root.children[0].textContent, /^\d{1,2} (\w+([+-]\d+)?)$/)
-    assert.equal(root.children[0].textContent, '0 GMT+1')
+    assert.equal(root.children[0].textContent, '0 GMT+4')
   })
 
   test('updates time zone when the `time-zone-name` attribute changes', function () {
@@ -104,10 +104,10 @@ suite('local-time', function () {
     el.setAttribute('time-zone-name', 'short')
 
     fixture.appendChild(el)
-    assert.equal(el.textContent, '1/1/1970, GMT+1')
+    assert.equal(el.textContent, '1/1/1970, GMT+4')
 
     el.setAttribute('time-zone-name', 'long')
 
-    assert.equal(el.textContent, '1/1/1970, GMT+01:00')
+    assert.equal(el.textContent, '1/1/1970, Gulf Standard Time')
   })
 })


### PR DESCRIPTION
Changing the `time-zone-name` attribute does not trigger a re-render of the `<local-time>` component. This behavior is a bug that I'm fixing in this pull request by adding `time-zone-name` to the list of observed attributes in `ExtendedTimeElement`.

> Note that to get the attributeChangedCallback() callback to fire when an attribute changes, you have to observe the attributes. This is done by specifying a static get observedAttributes() method inside custom element class - this should return  an array containing the names of the attributes you want to observe.

https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements

To be able to test this change, we need to pin the timezone. I pinned it to Dubai time since it seems to me to be a well-supported timezone but not typical for systems to default to like GMT, UTC, or any American timezones.

## References
[StackOverflow - How to pin a timezone in Chrome](https://stackoverflow.com/questions/44463925/headless-google-chrome-change-timezone)
