### PR TITLE
Update caniuse URL to new pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Browsers without native [custom element support][support] require a [polyfill][]
 - Safari
 - Microsoft Edge
 
-[support]: https://caniuse.com/#feat=custom-elementsv1
+[support]: https://caniuse.com/custom-elementsv1
 [polyfill]: https://github.com/webcomponents/custom-elements
 
 ## See Also


### PR DESCRIPTION
<https://caniuse.com/#feat=custom-elementsv1> is being redirected to <https://caniuse.com/custom-elementsv1> anyway, but the latter is visibly faster to me.

If you let me or want me to, I'll change the URL for each component of <https://github.com/github/github-elements> :)