### PR TITLE
Add file extensions to imports for ES Module support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import LocalTimeElement from './local-time-element'
-import RelativeTimeElement from './relative-time-element'
-import TimeAgoElement from './time-ago-element'
-import TimeUntilElement from './time-until-element'
+import LocalTimeElement from './local-time-element.js'
+import RelativeTimeElement from './relative-time-element.js'
+import TimeAgoElement from './time-ago-element.js'
+import TimeUntilElement from './time-until-element.js'
 
 export {LocalTimeElement, RelativeTimeElement, TimeAgoElement, TimeUntilElement}


### PR DESCRIPTION
This PR adds `.js` extensions to all the import paths in `index.ts`. This is necessary to ensure that the output `dist/index.d.ts` file also contains those extensions, which is necessary for this package to typecheck correctly for consumers that are using ES Modules.

Closes #167.