### PR TITLE
Add extensions to all imports

### DIFF
--- a/src/extended-time-element.ts
+++ b/src/extended-time-element.ts
@@ -1,4 +1,4 @@
-import {makeFormatter} from './utils'
+import {makeFormatter} from './utils.js'
 
 const datetimes = new WeakMap()
 

--- a/src/local-time-element.ts
+++ b/src/local-time-element.ts
@@ -1,5 +1,5 @@
-import {strftime, makeFormatter, isDayFirst} from './utils'
-import ExtendedTimeElement from './extended-time-element'
+import {strftime, makeFormatter, isDayFirst} from './utils.js'
+import ExtendedTimeElement from './extended-time-element.js'
 
 const formatters = new WeakMap()
 

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -1,6 +1,6 @@
-import RelativeTime from './relative-time'
-import ExtendedTimeElement from './extended-time-element'
-import {localeFromElement} from './utils'
+import RelativeTime from './relative-time.js'
+import ExtendedTimeElement from './extended-time-element.js'
+import {localeFromElement} from './utils.js'
 
 export default class RelativeTimeElement extends ExtendedTimeElement {
   getFormattedDate(): string | undefined {

--- a/src/relative-time.ts
+++ b/src/relative-time.ts
@@ -1,4 +1,4 @@
-import {strftime, makeFormatter, makeRelativeFormat, isDayFirst, isThisYear, isYearSeparator} from './utils'
+import {strftime, makeFormatter, makeRelativeFormat, isDayFirst, isThisYear, isYearSeparator} from './utils.js'
 
 export default class RelativeTime {
   date: Date

--- a/src/time-ago-element.ts
+++ b/src/time-ago-element.ts
@@ -1,6 +1,6 @@
-import RelativeTime from './relative-time'
-import RelativeTimeElement from './relative-time-element'
-import {localeFromElement} from './utils'
+import RelativeTime from './relative-time.js'
+import RelativeTimeElement from './relative-time-element.js'
+import {localeFromElement} from './utils.js'
 
 export default class TimeAgoElement extends RelativeTimeElement {
   getFormattedDate(): string | undefined {

--- a/src/time-until-element.ts
+++ b/src/time-until-element.ts
@@ -1,6 +1,6 @@
-import RelativeTime from './relative-time'
-import RelativeTimeElement from './relative-time-element'
-import {localeFromElement} from './utils'
+import RelativeTime from './relative-time.js'
+import RelativeTimeElement from './relative-time-element.js'
+import {localeFromElement} from './utils.js'
 
 export default class TimeUntilElement extends RelativeTimeElement {
   getFormattedDate(): string | undefined {


### PR DESCRIPTION
In #168, I unfortunately forgot to add extensions to all the other files. This is necessary because their imports still appear in the generated `.d.ts` files.