### PR TITLE
simplify time-until/ago elements

### DIFF
--- a/src/time-ago-element.ts
+++ b/src/time-ago-element.ts
@@ -1,17 +1,9 @@
-import RelativeTime from './relative-time.js'
+import {Tense} from './relative-time.js'
 import RelativeTimeElement from './relative-time-element.js'
-import {localeFromElement} from './utils.js'
 
 export default class TimeAgoElement extends RelativeTimeElement {
-  getFormattedDate(): string | undefined {
-    const format = this.getAttribute('format')
-    const date = this.date
-    if (!date) return
-    if (format === 'micro') {
-      return new RelativeTime(date, localeFromElement(this)).microTimeAgo()
-    } else {
-      return new RelativeTime(date, localeFromElement(this)).timeAgo()
-    }
+  get tense(): Tense {
+    return 'past'
   }
 }
 

--- a/src/time-until-element.ts
+++ b/src/time-until-element.ts
@@ -1,17 +1,9 @@
-import RelativeTime from './relative-time.js'
+import {Tense} from './relative-time.js'
 import RelativeTimeElement from './relative-time-element.js'
-import {localeFromElement} from './utils.js'
 
 export default class TimeUntilElement extends RelativeTimeElement {
-  getFormattedDate(): string | undefined {
-    const format = this.getAttribute('format')
-    const date = this.date
-    if (!date) return
-    if (format === 'micro') {
-      return new RelativeTime(date, localeFromElement(this)).microTimeUntil()
-    } else {
-      return new RelativeTime(date, localeFromElement(this)).timeUntil()
-    }
+  get tense(): Tense {
+    return 'future'
   }
 }
 


### PR DESCRIPTION
Now RelativeTimeElement supports `tense`, the `TimeAgo` and `TimeUntil` elements can be drastically simplified by fixing the `tense` value for these elements.