### PR TITLE
RelativeTimeElement: Progressive time update intervals

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -80,9 +80,30 @@
   <p>
     Relative time with custom format:
     <relative-time datetime="2017-01-01T00:00:00.000Z" format="%Y-%m-%d">
+  <p>
+
+  <p>
+    Nearby, dynamic, relative time:
+    <relative-time datetime="2019-08-12T20:50:00.000Z" id="dynamic1">
       Oops! This browser doesn't support Web Components.
     </relative-time>
   </p>
+
+  <p>
+    Nearby, dynamic, relative time:
+    <relative-time datetime="2019-08-12T20:50:00.000Z" id="dynamic2">
+      Oops! This browser doesn't support Web Components.
+    </relative-time>
+  </p>
+
+  <p>
+    Nearby, dynamic, relative time:
+    <relative-time datetime="2019-08-12T20:50:00.000Z" tense="past" id="dynamic3">
+      Oops! This browser doesn't support Web Components.
+    </relative-time>
+  </p>
+
+
 
   <p>
     Time until:
@@ -97,7 +118,15 @@
       Oops! This browser doesn't support Web Components.
     </time-until>
   </p>
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/time-elements@latest?module"></script>
+  <script type="module" src="../dist/index.js"></script>
+  <!-- <script type="module" src="https://unpkg.com/@github/time-elements@latest?module"></script> -->
+  <script>
+    document.body.addEventListener('relative-time-updated', event => {
+      console.log('event from', event.target, event)
+    });
+    document.getElementById('dynamic1').date = new Date()
+    document.getElementById('dynamic2').date = new Date(Date.now() - 30000)
+    document.getElementById('dynamic3').date = new Date(Date.now() + 5000)
+  </script>
 </body>
 </html>


### PR DESCRIPTION
This takes the work from #122 and updates it in line with the changes to the codebase. (Subsequently, this closes #122)

When updating `nowElements`, figure out how far away in time the nearest one is to ensure timely updates:
If an element is within
  - one minute from now, update a second after last run
  - one hour from now - update a minute after last run
  - more than one hour from now - update hourly after last run

Switching to setTimeout ensures that with a lot of attached instances, where a run might take a while, we won't schedule the next run until after all elements have been updated.

Also fire a `relative-time-updated` event if `textContent` changes in case this needs to be acted on.

Additionally it "unobserves" elements that are no longer displaying relative time, meaning the amount of time elements to update can decrease if they're not relative, or have fallen from the threshold of displaying relative time.

It also adds an `update()` method to house a lot of this logic, and a new private class to handle the observation of updates, making the concrete class a little simpler to reason about.