### PR TITLE
Experimental: `<relative-time>` supports thresholds that are specified by the user

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -540,7 +540,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       this.dispatchEvent(new RelativeTimeUpdatedEvent(oldText, newText, oldTitle, newTitle))
     }
 
-    if ((format === 'relative' || format === 'duration') && !displayUserPreferredAbsoluteTime) {
+    if (format === 'relative' || format === 'duration') {
       dateObserver.observe(this)
     } else {
       dateObserver.unobserve(this)

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -154,9 +154,19 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
 
     // 'auto' is an alias for 'relative'
     if ((format === 'auto' || format === 'relative') && typeof Intl !== 'undefined' && Intl.RelativeTimeFormat) {
-      const tense = this.tense
-      if (tense === 'past' || tense === 'future') return 'relative'
-      if (Duration.compare(duration, this.threshold) === 1) return 'relative'
+      // This attribute will only be present if the user has setting enabled
+      const userPreferredThreshold = this.ownerDocument.body?.getAttribute('data-preferred-threshold')
+      if (userPreferredThreshold) {
+        // "PT0S" would be at threshold of 0 seconds, corresponding to "always show absolute time"
+        if (isDuration(userPreferredThreshold)) {
+          if (Duration.compare(duration, userPreferredThreshold) === 1) return 'relative'
+        }
+        return 'datetime'
+      } else {
+        const tense = this.tense
+        if (tense === 'past' || tense === 'future') return 'relative'
+        if (Duration.compare(duration, this.threshold) === 1) return 'relative'
+      }
     }
     return 'datetime'
   }

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -513,7 +513,12 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     // Experimental: Enable absolute time if users prefers it, but never for `duration` format
     const displayUserPreferredAbsoluteTime = this.#shouldDisplayUserPreferredAbsoluteTime(format)
     if (displayUserPreferredAbsoluteTime) {
-      newText = this.#getUserPreferredAbsoluteTimeFormat(date)
+      if (format === 'relative') {
+        newText = this.#getRelativeFormat(duration)
+      } else {
+        // datetime
+        newText = this.#getUserPreferredAbsoluteTimeFormat(date)
+      }
     } else {
       if (format === 'duration') {
         newText = this.#getDurationFormat(duration)

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -157,7 +157,12 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       // This attribute will only be present if the user has setting enabled
       const userPreferredThreshold = this.ownerDocument.body?.getAttribute('data-preferred-threshold')
       if (userPreferredThreshold) {
-        // "PT0S" would be at threshold of 0 seconds, corresponding to "always show absolute time"
+        // Possible values of ISO 8601 durations for our cases are:
+        //  - "PT0S" (always) would be a threshold of 0 seconds, corresponding to always showing absolute time
+        //  - "P1D" (1 day)
+        //  - "P7D" (1 week)
+        //  - "P1M" (1 month)
+        //  - "P1Y" (1 year)
         if (isDuration(userPreferredThreshold)) {
           if (Duration.compare(duration, userPreferredThreshold) === 1) return 'relative'
         }


### PR DESCRIPTION
These changes enable the `<relative-time>` element to support user-supplied thresholds that pull from the value of a newly defined `data-preferred-threshold` attribute. The distinction between this feature and the pre-existing `threshold` support offered by the element already is that it will theoretically enable per-user specification of preferred thresholds over all `<relative-time>` elements. This would enable us to support something akin to a user setting allowing a developer to decide how long times show up as relative before they are shown as absolute time representations.