### PR TITLE
Experimental: Check for override attribute `disable-preference-override`

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -245,7 +245,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     if (format === 'duration') return false
 
     // Override for user preferences; used sparingly to preserve intended relative formatting in some places
-    if (this.hasAttribute('ignore-user-time-preference')) return false
+    if (this.hasAttribute('disable-preference-override')) return false
 
     return (
       this.ownerDocument.documentElement.getAttribute('data-prefers-absolute-time') === 'true' ||

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -244,6 +244,9 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     // Never override duration format with absolute format.
     if (format === 'duration') return false
 
+    // Override for user preferences; used sparingly to preserve intended relative formatting in some places
+    if (this.hasAttribute('ignore-user-time-preference')) return false
+
     return (
       this.ownerDocument.documentElement.getAttribute('data-prefers-absolute-time') === 'true' ||
       this.ownerDocument.body?.getAttribute('data-prefers-absolute-time') === 'true'


### PR DESCRIPTION
Now, part of the check for determining if we should display user time preferences will also check for whether there is a specific attribute on the element, `disable-preference-override`. If this attribute is present, we will use whatever the default behavior/display options are for the element, rather than displaying with absolute time.

This will enable us to selectively override elements in certain UIs even when a user setting to enable absolute time has been enabled. This will allow us to roll out changes without breaking parts of the UI we already know can't handle longer timestamps well.