### PR TITLE
feat: export duration module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./define": "./dist/index.js",
+    "./duration": "./dist/duration.js",
     "./relative-time": "./dist/relative-time-element.js",
     "./relative-time/define": "./dist/relative-time-element-define.js"
   },


### PR DESCRIPTION
Export the duration module, allowing the utility to be used without the HTML element.

My current workaround is to have this in a package.json `postinstall` script

```sh
TARGET=node_modules/@github/relative-time-element/package.json
cat <<< "$(jq '.exports["./duration"] = "./dist/duration.js"' $TARGET)" > $TARGET
```