### PR TITLE
Install Playwright browsers in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
       - run: npm install -g npm@latest
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npm test
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
@@ -41,6 +42,7 @@ jobs:
           cache: npm
           scope: '@github'
       - run: npm ci
+      - run: npx playwright install --with-deps chromium
       - run: npm test
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:


### PR DESCRIPTION
The publish workflow fails on `npm test` because Playwright's Chromium binary isn't available on the runner:
 
Failed workflow run: https://github.com/github/relative-time-element/actions/runs/27169511742