### PR TITLE
Restore NODE_AUTH_TOKEN for GitHub Packages publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,4 +48,5 @@ jobs:
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
       - run: npm --ignore-scripts publish --provenance --access public
-
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `publish-github` job in `publish.yml` [failed](https://github.com/github/relative-time-element/actions/runs/27219611057/job/80370657253) during the v5.1.0 release with `401 Unauthorized` when pushing to `npm.pkg.github.com`:

> npm error 401 Unauthorized - PUT https://npm.pkg.github.com/@github%2frelative-time-element - unauthenticated: User cannot be authenticated with the token provided.

This is a regression from a8c32fc, which added `id-token: write` to the GPR job and removed `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` from the publish step.

That change appears to mirror the OIDC trusted-publisher flow we use for npmjs.org, but `npm.pkg.github.com` still requires `NODE_AUTH_TOKEN` to authenticate the publish.

This PR restores `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` on the GPR publish step.