### PR TITLE
perf: skip redundant render-root and title writes on no-op ticks

### DIFF
--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -383,8 +383,8 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       root.replaceChildren(span)
     }
     if (ariaHidden) {
-      span.setAttribute('aria-hidden', 'true')
-    } else {
+      if (span.getAttribute('aria-hidden') !== 'true') span.setAttribute('aria-hidden', 'true')
+    } else if (span.hasAttribute('aria-hidden')) {
       span.removeAttribute('aria-hidden')
     }
     if (span.textContent !== content) {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -364,13 +364,28 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #updateRenderRootContent(content: string | null): void {
+    const root = this.#renderRoot as Element
+    const ariaHidden = this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true'
+    // Avoid dirtying the DOM (and invalidating layout) when nothing has changed.
+    // This is common on periodic ticks where the rendered text is identical to
+    // the previous tick (e.g. an item that still reads "3mo").
+    const current = root.firstElementChild
+    if (
+      current &&
+      root.childNodes.length === 1 &&
+      current.getAttribute('part') === 'root' &&
+      current.textContent === content &&
+      (current.getAttribute('aria-hidden') === 'true') === ariaHidden
+    ) {
+      return
+    }
     const span = document.createElement('span')
     span.setAttribute('part', 'root')
-    if (this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true') {
+    if (ariaHidden) {
       span.setAttribute('aria-hidden', 'true')
     }
     span.textContent = content
-    ;(this.#renderRoot as Element).replaceChildren(span)
+    root.replaceChildren(span)
   }
 
   #shouldDisplayUserPreferredAbsoluteTime(format: ResolvedFormat): boolean {
@@ -626,7 +641,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     const now = Date.now()
     if (!this.#customTitle) {
       newTitle = this.#getFormattedTitle(date) || ''
-      if (newTitle && !this.noTitle) this.setAttribute('title', newTitle)
+      if (newTitle && !this.noTitle && newTitle !== oldTitle) this.setAttribute('title', newTitle)
     }
 
     const duration = elapsedTime(date, this.precision, now)

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -164,7 +164,11 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return isBrowser12hCycle() ? 'h12' : 'h23'
   }
 
-  #renderRoot: Node = this.shadowRoot ? this.shadowRoot : this.attachShadow ? this.attachShadow({mode: 'open'}) : this
+  #renderRoot: Node & ParentNode = this.shadowRoot
+    ? this.shadowRoot
+    : this.attachShadow
+    ? this.attachShadow({mode: 'open'})
+    : this
 
   static get observedAttributes() {
     return [
@@ -364,28 +368,28 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #updateRenderRootContent(content: string | null): void {
-    const root = this.#renderRoot as Element
+    const root = this.#renderRoot
     const ariaHidden = this.hasAttribute('aria-hidden') && this.getAttribute('aria-hidden') === 'true'
-    // Avoid dirtying the DOM (and invalidating layout) when nothing has changed.
+    // Reuse the existing `part="root"` span across ticks and mutate it in place.
+    // Reading the DOM tree/attributes below does not force style or layout recalc
+    // (unlike geometry reads such as offsetWidth or innerText), so the only cost
+    // that matters is the write — which we skip when nothing actually changed.
     // This is common on periodic ticks where the rendered text is identical to
     // the previous tick (e.g. an item that still reads "3mo").
-    const current = root.firstElementChild
-    if (
-      current &&
-      root.childNodes.length === 1 &&
-      current.getAttribute('part') === 'root' &&
-      current.textContent === content &&
-      (current.getAttribute('aria-hidden') === 'true') === ariaHidden
-    ) {
-      return
+    let span = root.firstElementChild
+    if (!span || span.getAttribute('part') !== 'root' || root.childNodes.length !== 1) {
+      span = document.createElement('span')
+      span.setAttribute('part', 'root')
+      root.replaceChildren(span)
     }
-    const span = document.createElement('span')
-    span.setAttribute('part', 'root')
     if (ariaHidden) {
       span.setAttribute('aria-hidden', 'true')
+    } else {
+      span.removeAttribute('aria-hidden')
     }
-    span.textContent = content
-    root.replaceChildren(span)
+    if (span.textContent !== content) {
+      span.textContent = content
+    }
   }
 
   #shouldDisplayUserPreferredAbsoluteTime(format: ResolvedFormat): boolean {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -109,6 +109,37 @@ suite('relative-time', function () {
     assert.equal(counter, 1)
   })
 
+  test('does not rebuild the render root when the displayed text is unchanged', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
+    fixture.append(el)
+    await Promise.resolve()
+    const root = el.shadowRoot.querySelector('[part="root"]')
+    assert.ok(root, 'expected a rendered [part="root"] element')
+    const text = root.textContent
+
+    // A subsequent update that produces the same text must not replace the node.
+    el.update()
+    await Promise.resolve()
+    const rootAfter = el.shadowRoot.querySelector('[part="root"]')
+    assert.equal(rootAfter, root, 'render root node should be reused when text is unchanged')
+    assert.equal(rootAfter.textContent, text)
+  })
+
+  test('rebuilds the render root when the displayed text changes', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
+    fixture.append(el)
+    await Promise.resolve()
+    const root = el.shadowRoot.querySelector('[part="root"]')
+    const text = root.textContent
+
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString())
+    await Promise.resolve()
+    const rootAfter = el.shadowRoot.querySelector('[part="root"]')
+    assert.notEqual(rootAfter.textContent, text, 'text should have changed')
+  })
+
   test('calls update even after nullish datetime', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', '')

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -141,6 +141,66 @@ suite('relative-time', function () {
     assert.notEqual(rootAfter.textContent, text, 'text should have changed')
   })
 
+  test('emits no shadow-root mutations on a no-op update', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
+    fixture.append(el)
+    await Promise.resolve()
+
+    const records = []
+    const observer = new MutationObserver(mutations => records.push(...mutations))
+    observer.observe(el.shadowRoot, {subtree: true, childList: true, characterData: true, attributes: true})
+    try {
+      el.update()
+      await Promise.resolve()
+    } finally {
+      observer.disconnect()
+    }
+    assert.deepEqual(records, [], 'a no-op update must not mutate the shadow root')
+  })
+
+  test('emits no shadow-root mutations on a no-op update when aria-hidden', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('aria-hidden', 'true')
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
+    fixture.append(el)
+    await Promise.resolve()
+    const span = el.shadowRoot.querySelector('[part="root"]')
+    assert.equal(span.getAttribute('aria-hidden'), 'true', 'aria-hidden should be mirrored onto the span')
+
+    const records = []
+    const observer = new MutationObserver(mutations => records.push(...mutations))
+    observer.observe(el.shadowRoot, {subtree: true, childList: true, characterData: true, attributes: true})
+    try {
+      el.update()
+      await Promise.resolve()
+    } finally {
+      observer.disconnect()
+    }
+    assert.deepEqual(records, [], 'a no-op update must not rewrite aria-hidden or text')
+  })
+
+  test('does not rewrite the title attribute on a no-op update', async () => {
+    const el = document.createElement('relative-time')
+    el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
+    fixture.append(el)
+    await Promise.resolve()
+    const title = el.getAttribute('title')
+    assert.ok(title, 'expected a formatted title to be set')
+
+    const records = []
+    const observer = new MutationObserver(mutations => records.push(...mutations))
+    observer.observe(el, {attributes: true, attributeFilter: ['title']})
+    try {
+      el.update()
+      await Promise.resolve()
+    } finally {
+      observer.disconnect()
+    }
+    assert.deepEqual(records, [], 'an unchanged formatted title must not be written again')
+    assert.equal(el.getAttribute('title'), title)
+  })
+
   test('calls update even after nullish datetime', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', '')

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -126,7 +126,7 @@ suite('relative-time', function () {
     assert.equal(rootAfter.textContent, text)
   })
 
-  test('rebuilds the render root when the displayed text changes', async () => {
+  test('reuses the render root node and updates text in place when the display changes', async () => {
     const el = document.createElement('relative-time')
     el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 1000).toISOString())
     fixture.append(el)
@@ -137,6 +137,7 @@ suite('relative-time', function () {
     el.setAttribute('datetime', new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString())
     await Promise.resolve()
     const rootAfter = el.shadowRoot.querySelector('[part="root"]')
+    assert.equal(rootAfter, root, 'render root node should be reused across a text change')
     assert.notEqual(rootAfter.textContent, text, 'text should have changed')
   })
 


### PR DESCRIPTION
## Summary

The shared `dateObserver` singleton drives every registered `<relative-time>` on a single timer, calling `update()` on each element per tick. Today `update()`:

- Unconditionally rebuilds the `[part="root"]` span via `replaceChildren(span)` in `#updateRenderRootContent`, and
- Re-sets the `title` attribute,

**even when the computed text/title are identical to what is already rendered.** This is common on periodic ticks (e.g. an item that still reads `"3mo"`, or any element whose display hasn't crossed a unit boundary since the last tick). Each no-op write still invalidates style for the element, so pages with many `<relative-time>` elements pay avoidable style-invalidation churn every tick.

This is the "skip the DOM write when nothing changed" optimization — no public API change, no behavior change.

## Changes

- `#updateRenderRootContent` now **reuses** the existing `[part="root"]` span and mutates it **in place** rather than rebuilding it. The span is only recreated when it is missing or malformed (no `part="root"` span, or extra children). `textContent` and `aria-hidden` are each written only when their value actually changes, so unchanged ticks perform no DOM writes while `aria-hidden` toggles still take effect.
- `update()` skips `setAttribute('title', …)` when the new title equals the current one.

## Tests

Added tests to `test/relative-time.js`:
- render-root node is **reused** when a subsequent `update()` produces the same text.
- render-root node is **reused** and its text is updated in place when the displayed text changes (node identity is retained across text changes).
- a no-op `update()` emits **no** shadow-root mutations (verified with a `MutationObserver`), including an `aria-hidden="true"` case.
- an unchanged formatted `title` is **not** written again on a no-op `update()`.

Full suite passes in Chromium.

## Notes / scope

This is the low-risk, in-library slice of a broader perf discussion. It intentionally does **not** add offscreen pausing (an `IntersectionObserver` in `dateObserver`) — that's a larger, behavior-changing follow-up worth profiling first, since `content-visibility: auto` in consuming apps already skips layout/paint for offscreen ticks.
