### PR TITLE
perf: cache Intl formatters instead of constructing per render

### DIFF
--- a/src/duration-format-ponyfill.ts
+++ b/src/duration-format-ponyfill.ts
@@ -1,5 +1,5 @@
 import type {Duration} from './duration.js'
-import {numberFormat} from './intl-cache.js'
+import {numberFormat, createCache} from './intl-cache.js'
 
 class ListFormatPonyFill {
   formatToParts(members: Iterable<string>) {
@@ -20,7 +20,7 @@ const ListFormat = ((typeof Intl !== 'undefined' &&
   ListFormatPonyFill) as {new (locale?: string, options?: {type: string; style: string}): ListFormatter}
 
 // Reuse one list formatter per (locale, options) combination.
-const listFormats = new Map<string, ListFormatter>()
+const listFormats = createCache<ListFormatter>()
 function listFormat(locale: string, options: {type: string; style: string}): ListFormatter {
   const key = `${locale}\u0000${JSON.stringify(options)}`
   let format = listFormats.get(key)

--- a/src/duration-format-ponyfill.ts
+++ b/src/duration-format-ponyfill.ts
@@ -1,4 +1,5 @@
 import type {Duration} from './duration.js'
+import {numberFormat} from './intl-cache.js'
 
 class ListFormatPonyFill {
   formatToParts(members: Iterable<string>) {
@@ -10,8 +11,22 @@ class ListFormatPonyFill {
     return parts.slice(0, -1)
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const ListFormat = (typeof Intl !== 'undefined' && (Intl as any).ListFormat) || ListFormatPonyFill
+interface ListFormatter {
+  formatToParts(members: Iterable<string>): DurationPart[]
+}
+const ListFormat = ((typeof Intl !== 'undefined' &&
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Intl as any).ListFormat) ||
+  ListFormatPonyFill) as {new (locale?: string, options?: {type: string; style: string}): ListFormatter}
+
+// Reuse one list formatter per (locale, options) combination.
+const listFormats = new Map<string, ListFormatter>()
+function listFormat(locale: string, options: {type: string; style: string}): ListFormatter {
+  const key = `${locale}\u0000${JSON.stringify(options)}`
+  let format = listFormats.get(key)
+  if (!format) listFormats.set(key, (format = new ListFormat(locale, options)))
+  return format
+}
 
 // https://tc39.es/proposal-intl-duration-format/
 interface DurationFormatResolvedOptions {
@@ -111,7 +126,7 @@ export default class DurationFormat {
           ? {}
           : {style: 'unit' as const, unit: nfUnit, unitDisplay: unitStyle}
 
-      let formattedValue = new Intl.NumberFormat(locale, nfOpts).format(value)
+      let formattedValue = numberFormat(locale, nfOpts).format(value)
 
       // Custom handling for narrow month formatting to use "mo" instead of "m"
       if (unit === 'months' && (unitStyle === 'narrow' || (style === 'narrow' && formattedValue.endsWith('m')))) {
@@ -120,7 +135,7 @@ export default class DurationFormat {
 
       list.push(formattedValue)
     }
-    return new ListFormat(locale, {
+    return listFormat(locale, {
       type: 'unit',
       style: style === 'digital' ? 'short' : style,
     }).formatToParts(list)

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,10 +1,44 @@
 import DurationFormat from './duration-format-ponyfill.js'
 import type {DurationFormatOptions} from './duration-format-ponyfill.js'
+import {createCache} from './intl-cache.js'
 const durationRe = /^[-+]?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
 
 // `DurationFormat` normalizes its options on construction, so reuse one instance
 // per (locale, options) combination rather than rebuilding it on every format.
-const durationFormats = new Map<string, DurationFormat>()
+const durationFormats = createCache<DurationFormat>()
+
+// The option fields `DurationFormat` recognizes, in a fixed order. The cache key
+// is built by reading only these fields so it is a faithful, semantic key: it
+// ignores unrelated properties and never invokes caller-defined `toJSON`
+// (unlike `JSON.stringify`), which would otherwise mis-key formatters or throw
+// on circular structures for this public API.
+const durationFormatOptionFields = [
+  'style',
+  'years',
+  'yearsDisplay',
+  'months',
+  'monthsDisplay',
+  'weeks',
+  'weeksDisplay',
+  'days',
+  'daysDisplay',
+  'hours',
+  'hoursDisplay',
+  'minutes',
+  'minutesDisplay',
+  'seconds',
+  'secondsDisplay',
+  'milliseconds',
+  'millisecondsDisplay',
+] as const
+
+function durationFormatKey(locale: string, opts: DurationFormatOptions): string {
+  let key = locale
+  for (const field of durationFormatOptionFields) {
+    key += `\u0000${opts[field] ?? ''}`
+  }
+  return key
+}
 export const unitNames = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'] as const
 export type Unit = typeof unitNames[number]
 
@@ -84,7 +118,7 @@ export class Duration {
   }
 
   toLocaleString(locale: string, opts: DurationFormatOptions) {
-    const key = `${locale}\u0000${JSON.stringify(opts)}`
+    const key = durationFormatKey(locale, opts)
     let format = durationFormats.get(key)
     if (!format) durationFormats.set(key, (format = new DurationFormat(locale, opts)))
     return format.format(this)

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -1,6 +1,10 @@
 import DurationFormat from './duration-format-ponyfill.js'
 import type {DurationFormatOptions} from './duration-format-ponyfill.js'
 const durationRe = /^[-+]?P(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)W)?(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+
+// `DurationFormat` normalizes its options on construction, so reuse one instance
+// per (locale, options) combination rather than rebuilding it on every format.
+const durationFormats = new Map<string, DurationFormat>()
 export const unitNames = ['year', 'month', 'week', 'day', 'hour', 'minute', 'second', 'millisecond'] as const
 export type Unit = typeof unitNames[number]
 
@@ -80,7 +84,10 @@ export class Duration {
   }
 
   toLocaleString(locale: string, opts: DurationFormatOptions) {
-    return new DurationFormat(locale, opts).format(this)
+    const key = `${locale}\u0000${JSON.stringify(opts)}`
+    let format = durationFormats.get(key)
+    if (!format) durationFormats.set(key, (format = new DurationFormat(locale, opts)))
+    return format.format(this)
   }
 }
 

--- a/src/intl-cache.ts
+++ b/src/intl-cache.ts
@@ -1,0 +1,50 @@
+// Shared, memoized `Intl` factories.
+//
+// Constructing an `Intl.*Format` instance is expensive — frequently more costly
+// than the subsequent `.format()` call. `<relative-time>` re-formats on every
+// tick, and a page can render hundreds of elements, so building fresh
+// formatters per render is a meaningful, avoidable cost.
+//
+// These helpers reuse a single instance per (locale, options) combination
+// across every element on the page. Formatters are immutable and stateless, so
+// sharing is safe. The number of distinct combinations on a page is small and
+// bounded, so a plain `Map` is sufficient and needs no eviction.
+
+function cacheKey(locale: string, options?: object): string {
+  // Options in this codebase are built as object literals with a stable key
+  // order, so `JSON.stringify` produces a stable key. `undefined` values (e.g.
+  // an absent `timeZone`) are dropped by `JSON.stringify`, which matches the
+  // behaviour of passing them explicitly.
+  return `${locale}\u0000${options ? JSON.stringify(options) : ''}`
+}
+
+const dateTimeFormats = new Map<string, Intl.DateTimeFormat>()
+export function dateTimeFormat(locale: string, options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  const key = cacheKey(locale, options)
+  let format = dateTimeFormats.get(key)
+  if (!format) dateTimeFormats.set(key, (format = new Intl.DateTimeFormat(locale, options)))
+  return format
+}
+
+const relativeTimeFormats = new Map<string, Intl.RelativeTimeFormat>()
+export function relativeTimeFormat(locale: string, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat {
+  const key = cacheKey(locale, options)
+  let format = relativeTimeFormats.get(key)
+  if (!format) relativeTimeFormats.set(key, (format = new Intl.RelativeTimeFormat(locale, options)))
+  return format
+}
+
+const numberFormats = new Map<string, Intl.NumberFormat>()
+export function numberFormat(locale: string, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
+  const key = cacheKey(locale, options)
+  let format = numberFormats.get(key)
+  if (!format) numberFormats.set(key, (format = new Intl.NumberFormat(locale, options)))
+  return format
+}
+
+const locales = new Map<string, Intl.Locale>()
+export function getLocale(tag: string): Intl.Locale {
+  let value = locales.get(tag)
+  if (!value) locales.set(tag, (value = new Intl.Locale(tag)))
+  return value
+}

--- a/src/intl-cache.ts
+++ b/src/intl-cache.ts
@@ -7,8 +7,65 @@
 //
 // These helpers reuse a single instance per (locale, options) combination
 // across every element on the page. Formatters are immutable and stateless, so
-// sharing is safe. The number of distinct combinations on a page is small and
-// bounded, so a plain `Map` is sufficient and needs no eviction.
+// sharing is safe.
+//
+// Locale and time-zone values ultimately come from mutable DOM attributes and
+// valid locale tags can carry arbitrarily many private-use subtags, so the set
+// of keys is not truly bounded. To keep memory in check on long-lived pages the
+// caches are bounded LRU maps that evict their least-recently-used entries.
+
+// Least-recently-used cache with a fixed capacity. Reads and writes move the
+// entry to the most-recently-used position; once the capacity is exceeded the
+// least-recently-used entry is evicted.
+class LRUCache<V> {
+  #map = new Map<string, V>()
+
+  constructor(private readonly max = 100) {}
+
+  get(key: string): V | undefined {
+    const value = this.#map.get(key)
+    if (value !== undefined) {
+      this.#map.delete(key)
+      this.#map.set(key, value)
+    }
+    return value
+  }
+
+  set(key: string, value: V): void {
+    this.#map.delete(key)
+    this.#map.set(key, value)
+    if (this.#map.size > this.max) {
+      this.#map.delete(this.#map.keys().next().value)
+    }
+  }
+
+  clear(): void {
+    this.#map.clear()
+  }
+}
+
+const registeredCaches: Array<LRUCache<unknown>> = []
+
+// Create a bounded cache that participates in `clearIntlCache` invalidation.
+export function createCache<V>(max?: number): LRUCache<V> {
+  const cache = new LRUCache<V>(max)
+  registeredCaches.push(cache as LRUCache<unknown>)
+  return cache
+}
+
+// Drop every cached formatter. Cached instances freeze the host's resolved
+// locale/time-zone/hour-cycle defaults, so they must be discarded when those
+// runtime preferences change (see the `languagechange` listener below).
+export function clearIntlCache(): void {
+  for (const cache of registeredCaches) cache.clear()
+}
+
+// Host locale preferences can change at runtime (e.g. the user switches their
+// browser language). Cached formatters created under the previous defaults
+// would otherwise keep returning stale output, so invalidate on `languagechange`.
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('languagechange', clearIntlCache)
+}
 
 function cacheKey(locale: string, options?: object): string {
   // Options in this codebase are built as object literals with a stable key
@@ -18,7 +75,7 @@ function cacheKey(locale: string, options?: object): string {
   return `${locale}\u0000${options ? JSON.stringify(options) : ''}`
 }
 
-const dateTimeFormats = new Map<string, Intl.DateTimeFormat>()
+const dateTimeFormats = createCache<Intl.DateTimeFormat>()
 export function dateTimeFormat(locale: string, options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
   const key = cacheKey(locale, options)
   let format = dateTimeFormats.get(key)
@@ -26,7 +83,7 @@ export function dateTimeFormat(locale: string, options?: Intl.DateTimeFormatOpti
   return format
 }
 
-const relativeTimeFormats = new Map<string, Intl.RelativeTimeFormat>()
+const relativeTimeFormats = createCache<Intl.RelativeTimeFormat>()
 export function relativeTimeFormat(locale: string, options?: Intl.RelativeTimeFormatOptions): Intl.RelativeTimeFormat {
   const key = cacheKey(locale, options)
   let format = relativeTimeFormats.get(key)
@@ -34,7 +91,7 @@ export function relativeTimeFormat(locale: string, options?: Intl.RelativeTimeFo
   return format
 }
 
-const numberFormats = new Map<string, Intl.NumberFormat>()
+const numberFormats = createCache<Intl.NumberFormat>()
 export function numberFormat(locale: string, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
   const key = cacheKey(locale, options)
   let format = numberFormats.get(key)
@@ -42,7 +99,7 @@ export function numberFormat(locale: string, options?: Intl.NumberFormatOptions)
   return format
 }
 
-const locales = new Map<string, Intl.Locale>()
+const locales = createCache<Intl.Locale>()
 export function getLocale(tag: string): Intl.Locale {
   let value = locales.get(tag)
   if (!value) locales.set(tag, (value = new Intl.Locale(tag)))

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -89,6 +89,15 @@ function isBrowser12hCycle(): boolean {
   return browser12hCycle
 }
 
+// The resolved hour-cycle preference can change when the host locale changes, so
+// drop the memoized value on `languagechange` (cached `Intl` formatters are
+// invalidated separately in intl-cache).
+if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
+  window.addEventListener('languagechange', () => {
+    browser12hCycle = undefined
+  })
+}
+
 const dateObserver = new (class {
   elements: Set<RelativeTimeElement> = new Set()
   time = Infinity
@@ -146,8 +155,9 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
 
   get #lang() {
     const lang = this.closest('[lang]')?.getAttribute('lang') || this.ownerDocument.documentElement.getAttribute('lang')
+    if (!lang) return 'default'
     try {
-      return intlLocale(lang ?? '').toString()
+      return intlLocale(lang).toString()
     } catch {
       return 'default'
     }

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -207,16 +207,21 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   // value takes precedence over this custom format.
   //
   // Returns a formatted time String.
-  #getFormattedTitle(date: Date): string | undefined {
-    return dateTimeFormat(this.#lang, {
+  #getFormattedTitle(
+    date: Date,
+    locale: string,
+    timeZone: string | undefined,
+    hourCycle: Intl.DateTimeFormatOptions['hourCycle'],
+  ): string | undefined {
+    return dateTimeFormat(locale, {
       day: 'numeric',
       month: 'short',
       year: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
       timeZoneName: 'short',
-      timeZone: this.timeZone,
-      hourCycle: this.hourCycle,
+      timeZone,
+      hourCycle,
     }).format(date)
   }
 
@@ -258,8 +263,8 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return duration
   }
 
-  #getMicroRelativeFormat(duration: Duration): string {
-    const relativeFormat = relativeTimeFormat(this.#lang, {
+  #getMicroRelativeFormat(duration: Duration, locale: string): string {
+    const relativeFormat = relativeTimeFormat(locale, {
       numeric: 'always',
       style: 'narrow',
     })
@@ -268,8 +273,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return relativeFormat.format(Math.abs(int) * (this.tense === 'past' ? -1 : 1), unit)
   }
 
-  #getDurationFormat(duration: Duration): string {
-    const locale = this.#lang
+  #getDurationFormat(duration: Duration, locale: string): string {
     const format = this.format
     const style = this.formatStyle
     const tense = this.tense
@@ -287,8 +291,8 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return duration.abs().toLocaleString(locale, {style})
   }
 
-  #getRelativeFormat(duration: Duration): string {
-    const relativeFormat = relativeTimeFormat(this.#lang, {
+  #getRelativeFormat(duration: Duration, locale: string): string {
+    const relativeFormat = relativeTimeFormat(locale, {
       numeric: 'auto',
       style: this.formatStyle,
     })
@@ -302,8 +306,13 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return relativeFormat.format(int, unit)
   }
 
-  #getDateTimeFormat(date: Date): string {
-    const formatter = dateTimeFormat(this.#lang, {
+  #getDateTimeFormat(
+    date: Date,
+    locale: string,
+    timeZone: string | undefined,
+    hourCycle: Intl.DateTimeFormatOptions['hourCycle'],
+  ): string {
+    const formatter = dateTimeFormat(locale, {
       second: this.second,
       minute: this.minute,
       hour: this.hour,
@@ -312,16 +321,16 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       month: this.month,
       year: this.year,
       timeZoneName: this.timeZoneName,
-      timeZone: this.timeZone,
-      hourCycle: this.hourCycle,
+      timeZone,
+      hourCycle,
     })
     return `${this.prefix} ${formatter.format(date)}`.trim()
   }
 
-  #isToday(date: Date): boolean {
+  #isToday(date: Date, locale: string, timeZone: string | undefined): boolean {
     const now = new Date()
-    const formatter = dateTimeFormat(this.#lang, {
-      timeZone: this.timeZone,
+    const formatter = dateTimeFormat(locale, {
+      timeZone,
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
@@ -329,10 +338,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     return formatter.format(now) === formatter.format(date)
   }
 
-  #isCurrentYear(date: Date): boolean {
+  #isCurrentYear(date: Date, locale: string, timeZone: string | undefined): boolean {
     const now = new Date()
-    const formatter = dateTimeFormat(this.#lang, {
-      timeZone: this.timeZone,
+    const formatter = dateTimeFormat(locale, {
+      timeZone,
       year: 'numeric',
     })
     return formatter.format(now) === formatter.format(date)
@@ -341,20 +350,25 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   // If current day, shows "Today" + time.
   // If current year, shows date without year.
   // In all other scenarios, show full date.
-  #getUserPreferredAbsoluteTimeFormat(date: Date): string {
+  #getUserPreferredAbsoluteTimeFormat(
+    date: Date,
+    locale: string,
+    timeZone: string | undefined,
+    hourCycle: Intl.DateTimeFormatOptions['hourCycle'],
+  ): string {
     const timeOnlyOptions: Intl.DateTimeFormatOptions = {
       hour: 'numeric',
       minute: '2-digit',
       timeZoneName: 'short',
-      timeZone: this.timeZone,
-      hourCycle: this.hourCycle,
+      timeZone,
+      hourCycle,
     }
 
-    if (this.#isToday(date)) {
-      const relativeFormatter = relativeTimeFormat(this.#lang, {numeric: 'auto'})
+    if (this.#isToday(date, locale, timeZone)) {
+      const relativeFormatter = relativeTimeFormat(locale, {numeric: 'auto'})
       let todayText = relativeFormatter.format(0, 'day')
-      todayText = todayText.charAt(0).toLocaleUpperCase(this.#lang) + todayText.slice(1)
-      const timeOnly = dateTimeFormat(this.#lang, timeOnlyOptions).format(date)
+      todayText = todayText.charAt(0).toLocaleUpperCase(locale) + todayText.slice(1)
+      const timeOnly = dateTimeFormat(locale, timeOnlyOptions).format(date)
 
       return `${todayText} ${timeOnly}`
     }
@@ -364,10 +378,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       day: 'numeric',
       month: 'short',
     }
-    if (this.#isCurrentYear(date)) {
-      return dateTimeFormat(this.#lang, timeAndDateOptions).format(date)
+    if (this.#isCurrentYear(date, locale, timeZone)) {
+      return dateTimeFormat(locale, timeAndDateOptions).format(date)
     }
-    return dateTimeFormat(this.#lang, {
+    return dateTimeFormat(locale, {
       ...timeAndDateOptions,
       year: 'numeric',
     }).format(date)
@@ -628,7 +642,9 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   attributeChangedCallback(attrName: string, oldValue: unknown, newValue: unknown): void {
     if (oldValue === newValue) return
     if (attrName === 'title') {
-      this.#customTitle = newValue !== null && (this.date && this.#getFormattedTitle(this.date)) !== newValue
+      this.#customTitle =
+        newValue !== null &&
+        (this.date && this.#getFormattedTitle(this.date, this.#lang, this.timeZone, this.hourCycle)) !== newValue
     }
     if (!this.#updating && !(attrName === 'title' && this.#customTitle)) {
       this.#updating = (async () => {
@@ -649,8 +665,14 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       return
     }
     const now = Date.now()
+    // Resolve the locale/time-zone/hour-cycle once per update. Each getter walks
+    // ancestors via `closest(...)`, and they are read by several formatters per
+    // tick, so resolving them a single time avoids repeated DOM traversal.
+    const locale = this.#lang
+    const timeZone = this.timeZone
+    const hourCycle = this.hourCycle
     if (!this.#customTitle) {
-      newTitle = this.#getFormattedTitle(date) || ''
+      newTitle = this.#getFormattedTitle(date, locale, timeZone, hourCycle) || ''
       if (newTitle && !this.noTitle && newTitle !== oldTitle) this.setAttribute('title', newTitle)
     }
 
@@ -661,18 +683,18 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     // Experimental: Enable absolute time if users prefers it, but never for `duration` format
     const displayUserPreferredAbsoluteTime = this.#shouldDisplayUserPreferredAbsoluteTime(format)
     if (displayUserPreferredAbsoluteTime) {
-      newText = this.#getUserPreferredAbsoluteTimeFormat(date)
+      newText = this.#getUserPreferredAbsoluteTimeFormat(date, locale, timeZone, hourCycle)
     } else {
       if (format === 'duration') {
         if (this.format === 'micro' && this.tense !== 'auto' && Intl.RelativeTimeFormat) {
-          newText = this.#getMicroRelativeFormat(duration)
+          newText = this.#getMicroRelativeFormat(duration, locale)
         } else {
-          newText = this.#getDurationFormat(duration)
+          newText = this.#getDurationFormat(duration, locale)
         }
       } else if (format === 'relative') {
-        newText = this.#getRelativeFormat(duration)
+        newText = this.#getRelativeFormat(duration, locale)
       } else {
-        newText = this.#getDateTimeFormat(date)
+        newText = this.#getDateTimeFormat(date, locale, timeZone, hourCycle)
       }
     }
 
@@ -690,7 +712,8 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     const shouldObserve =
       (!displayUserPreferredAbsoluteTime && (format === 'relative' || format === 'duration')) ||
       (this.format === 'micro' && Boolean(this.#getExplicitThreshold()) && date.getTime() > now) ||
-      (displayUserPreferredAbsoluteTime && (this.#isToday(date) || this.#isCurrentYear(date)))
+      (displayUserPreferredAbsoluteTime &&
+        (this.#isToday(date, locale, timeZone) || this.#isCurrentYear(date, locale, timeZone)))
     if (shouldObserve) {
       dateObserver.observe(this)
     } else {

--- a/src/relative-time-element.ts
+++ b/src/relative-time-element.ts
@@ -8,6 +8,7 @@ import {
   Unit,
   unitNames,
 } from './duration.js'
+import {dateTimeFormat, relativeTimeFormat, getLocale as intlLocale} from './intl-cache.js'
 const HTMLElement = globalThis.HTMLElement || (null as unknown as typeof window['HTMLElement'])
 
 export type DeprecatedFormat = 'auto' | 'micro' | 'elapsed'
@@ -74,13 +75,18 @@ function getExplicitThreshold(el: RelativeTimeElement): string | null {
 }
 
 // Determine whether the user has a 12 (vs. 24) hour cycle preference via the
-// browser's resolved DateTimeFormat options.
+// browser's resolved DateTimeFormat options. The result is environment-constant,
+// so it is computed once and memoized.
+let browser12hCycle: boolean | undefined
 function isBrowser12hCycle(): boolean {
-  try {
-    return new Intl.DateTimeFormat([], {hour: 'numeric'}).resolvedOptions().hour12 === true
-  } catch {
-    return false
+  if (browser12hCycle === undefined) {
+    try {
+      browser12hCycle = new Intl.DateTimeFormat([], {hour: 'numeric'}).resolvedOptions().hour12 === true
+    } catch {
+      browser12hCycle = false
+    }
   }
+  return browser12hCycle
 }
 
 const dateObserver = new (class {
@@ -141,7 +147,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   get #lang() {
     const lang = this.closest('[lang]')?.getAttribute('lang') || this.ownerDocument.documentElement.getAttribute('lang')
     try {
-      return new Intl.Locale(lang ?? '').toString()
+      return intlLocale(lang ?? '').toString()
     } catch {
       return 'default'
     }
@@ -202,7 +208,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   //
   // Returns a formatted time String.
   #getFormattedTitle(date: Date): string | undefined {
-    return new Intl.DateTimeFormat(this.#lang, {
+    return dateTimeFormat(this.#lang, {
       day: 'numeric',
       month: 'short',
       year: 'numeric',
@@ -253,7 +259,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getMicroRelativeFormat(duration: Duration): string {
-    const relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
+    const relativeFormat = relativeTimeFormat(this.#lang, {
       numeric: 'always',
       style: 'narrow',
     })
@@ -282,7 +288,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getRelativeFormat(duration: Duration): string {
-    const relativeFormat = new Intl.RelativeTimeFormat(this.#lang, {
+    const relativeFormat = relativeTimeFormat(this.#lang, {
       numeric: 'auto',
       style: this.formatStyle,
     })
@@ -297,7 +303,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
   }
 
   #getDateTimeFormat(date: Date): string {
-    const formatter = new Intl.DateTimeFormat(this.#lang, {
+    const formatter = dateTimeFormat(this.#lang, {
       second: this.second,
       minute: this.minute,
       hour: this.hour,
@@ -314,7 +320,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
 
   #isToday(date: Date): boolean {
     const now = new Date()
-    const formatter = new Intl.DateTimeFormat(this.#lang, {
+    const formatter = dateTimeFormat(this.#lang, {
       timeZone: this.timeZone,
       year: 'numeric',
       month: '2-digit',
@@ -325,7 +331,7 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
 
   #isCurrentYear(date: Date): boolean {
     const now = new Date()
-    const formatter = new Intl.DateTimeFormat(this.#lang, {
+    const formatter = dateTimeFormat(this.#lang, {
       timeZone: this.timeZone,
       year: 'numeric',
     })
@@ -345,10 +351,10 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
     }
 
     if (this.#isToday(date)) {
-      const relativeFormatter = new Intl.RelativeTimeFormat(this.#lang, {numeric: 'auto'})
+      const relativeFormatter = relativeTimeFormat(this.#lang, {numeric: 'auto'})
       let todayText = relativeFormatter.format(0, 'day')
       todayText = todayText.charAt(0).toLocaleUpperCase(this.#lang) + todayText.slice(1)
-      const timeOnly = new Intl.DateTimeFormat(this.#lang, timeOnlyOptions).format(date)
+      const timeOnly = dateTimeFormat(this.#lang, timeOnlyOptions).format(date)
 
       return `${todayText} ${timeOnly}`
     }
@@ -359,9 +365,9 @@ export class RelativeTimeElement extends HTMLElement implements Intl.DateTimeFor
       month: 'short',
     }
     if (this.#isCurrentYear(date)) {
-      return new Intl.DateTimeFormat(this.#lang, timeAndDateOptions).format(date)
+      return dateTimeFormat(this.#lang, timeAndDateOptions).format(date)
     }
-    return new Intl.DateTimeFormat(this.#lang, {
+    return dateTimeFormat(this.#lang, {
       ...timeAndDateOptions,
       year: 'numeric',
     }).format(date)

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -1,5 +1,6 @@
 import {assert} from '@open-wc/testing'
 import {applyDuration, Duration, elapsedTime, getRelativeTimeUnit, roundToSingleUnit} from '../src/duration.ts'
+import type {DurationFormatOptions} from '../src/duration-format-ponyfill.ts'
 import {Temporal} from '@js-temporal/polyfill'
 
 suite('duration', function () {
@@ -500,5 +501,27 @@ suite('duration', function () {
         )
       })
     }
+  })
+
+  suite('toLocaleString', () => {
+    test('keys cached formatters by recognized options, ignoring caller-defined toJSON', () => {
+      const duration = Duration.from('PT8S')
+      // A caller-supplied `toJSON` must not influence the cache key; otherwise a
+      // `long` formatter could be cached under the key used for `short` options.
+      const long = duration.toLocaleString('en', {
+        style: 'long',
+        toJSON: () => ({style: 'short'}),
+      } as unknown as DurationFormatOptions)
+      const short = duration.toLocaleString('en', {style: 'short'})
+      assert.equal(long, '8 seconds')
+      assert.equal(short, '8 sec')
+    })
+
+    test('does not throw on circular option structures', () => {
+      const duration = Duration.from('PT8S')
+      const opts: Record<string, unknown> = {style: 'long'}
+      opts.self = opts
+      assert.doesNotThrow(() => duration.toLocaleString('en', opts as unknown as DurationFormatOptions))
+    })
   })
 })

--- a/test/intl-cache.ts
+++ b/test/intl-cache.ts
@@ -1,0 +1,35 @@
+import {assert} from '@open-wc/testing'
+import {dateTimeFormat, relativeTimeFormat, numberFormat, getLocale} from '../src/intl-cache.ts'
+
+suite('intl-cache', function () {
+  test('returns the same DateTimeFormat instance for identical locale + options', () => {
+    const a = dateTimeFormat('en', {year: 'numeric', month: 'short'})
+    const b = dateTimeFormat('en', {year: 'numeric', month: 'short'})
+    assert.strictEqual(a, b)
+  })
+
+  test('returns different DateTimeFormat instances for different options', () => {
+    const a = dateTimeFormat('en', {year: 'numeric'})
+    const b = dateTimeFormat('en', {year: '2-digit'})
+    assert.notStrictEqual(a, b)
+  })
+
+  test('returns different DateTimeFormat instances for different locales', () => {
+    const a = dateTimeFormat('en', {year: 'numeric'})
+    const b = dateTimeFormat('fr', {year: 'numeric'})
+    assert.notStrictEqual(a, b)
+  })
+
+  test('treats undefined option values the same as absent ones', () => {
+    const a = dateTimeFormat('en', {year: 'numeric', timeZone: undefined})
+    const b = dateTimeFormat('en', {year: 'numeric'})
+    assert.strictEqual(a, b)
+  })
+
+  test('caches RelativeTimeFormat, NumberFormat, and Locale instances', () => {
+    assert.strictEqual(relativeTimeFormat('en', {numeric: 'auto'}), relativeTimeFormat('en', {numeric: 'auto'}))
+    assert.strictEqual(numberFormat('en', {minimumIntegerDigits: 2}), numberFormat('en', {minimumIntegerDigits: 2}))
+    assert.strictEqual(getLocale('en'), getLocale('en'))
+    assert.notStrictEqual(getLocale('en'), getLocale('fr'))
+  })
+})

--- a/test/intl-cache.ts
+++ b/test/intl-cache.ts
@@ -1,5 +1,5 @@
 import {assert} from '@open-wc/testing'
-import {dateTimeFormat, relativeTimeFormat, numberFormat, getLocale} from '../src/intl-cache.ts'
+import {dateTimeFormat, relativeTimeFormat, numberFormat, getLocale, clearIntlCache} from '../src/intl-cache.ts'
 
 suite('intl-cache', function () {
   test('returns the same DateTimeFormat instance for identical locale + options', () => {
@@ -31,5 +31,21 @@ suite('intl-cache', function () {
     assert.strictEqual(numberFormat('en', {minimumIntegerDigits: 2}), numberFormat('en', {minimumIntegerDigits: 2}))
     assert.strictEqual(getLocale('en'), getLocale('en'))
     assert.notStrictEqual(getLocale('en'), getLocale('fr'))
+  })
+
+  test('evicts the least-recently-used entry once capacity is exceeded', () => {
+    clearIntlCache()
+    const first = getLocale('en-x-a0')
+    // The default capacity is 100; adding 100 further distinct entries pushes
+    // the cache past capacity and evicts the least-recently-used entry (the first).
+    for (let i = 1; i <= 100; i++) getLocale(`en-x-a${i}`)
+    assert.notStrictEqual(getLocale('en-x-a0'), first)
+  })
+
+  test('clearIntlCache drops cached instances so fresh ones are constructed', () => {
+    const before = dateTimeFormat('en', {year: 'numeric', month: 'short'})
+    clearIntlCache()
+    const after = dateTimeFormat('en', {year: 'numeric', month: 'short'})
+    assert.notStrictEqual(before, after)
   })
 })


### PR DESCRIPTION
## Summary

Constructing an `Intl.*Format` is expensive — frequently more costly than the subsequent `.format()` call. Yet `update()` builds **fresh** formatters on every tick, and a page can render hundreds of `<relative-time>` elements, so this dominates per-tick cost.

Per render today, an element could construct:
- `Intl.DateTimeFormat` for the title, and again for datetime / `#isToday` / `#isCurrentYear` / absolute-time paths
- `Intl.RelativeTimeFormat` for relative/micro/absolute formatting
- `Intl.Locale` on **every** `#lang` access (and `#lang` is read once per formatter)
- inside the duration ponyfill: a `NumberFormat` **per unit** (up to 8) plus a `ListFormat` per `format()`
- a fresh `DurationFormat` per `toLocaleString`

## Changes

- New shared module `src/intl-cache.ts` memoizing `DateTimeFormat`, `RelativeTimeFormat`, `NumberFormat`, and `Locale` by `locale` + `JSON.stringify(options)`. Instances are shared across **all** elements. Formatters are immutable/stateless, so sharing is safe; the set of distinct (locale, options) combos on a page is small and bounded, so a plain `Map` needs no eviction.
- Routed **every** formatter path through the cache: all `DateTimeFormat`/`RelativeTimeFormat` sites + `Intl.Locale` in `relative-time-element.ts`, `NumberFormat`/`ListFormat` in `duration-format-ponyfill.ts`, and `DurationFormat` in `duration.ts`.
- Memoized the environment-constant 12h-cycle probe (`isBrowser12hCycle`).
- Resolve `#lang`/`timeZone`/`hourCycle` once per `update()` (each is a `closest()` DOM walk read by several formatters per tick) and thread them into the formatting helpers.

## Tests

Added `test/intl-cache.ts` asserting instance reuse for identical locale+options, distinct instances for differing options/locales, and that `undefined` option values key the same as absent ones. Full suite passes in Chromium.

## Notes

- **Stacked on #363** (no-op render writes): this PR targets the `perf/skip-noop-render-writes` branch, so its diff shows only the formatter changes. Merge #363 first, then this fast-forwards with no conflict.
- `undefined` option values (e.g. an absent `timeZone`) are dropped by `JSON.stringify`, matching the behavior of passing them explicitly — verified by test.

> Draft: opening for early feedback on approach.