### PR TITLE
Fix year precision for duration and elapsed formats

### DIFF
--- a/src/duration.ts
+++ b/src/duration.ts
@@ -156,7 +156,8 @@ export function elapsedTime(date: Date, precision: Unit = 'second', now = Date.n
   const day = Math.floor(hr / 24)
   const month = Math.floor(day / 30)
   const year = Math.floor(month / 12)
-  const i = unitNames.indexOf(precision) || unitNames.length
+  const precisionIndex = unitNames.indexOf(precision)
+  const i = precisionIndex === -1 ? unitNames.length : precisionIndex
   return new Duration(
     i >= 0 ? year * sign : 0,
     i >= 1 ? (month - year * 12) * sign : 0,

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -156,8 +156,7 @@ export function elapsedTime(date: Date, precision: Unit = 'second', now = Date.n
   const day = Math.floor(hr / 24)
   const month = Math.floor(day / 30)
   const year = Math.floor(month / 12)
-  const precisionIndex = unitNames.indexOf(precision)
-  const i = precisionIndex === -1 ? unitNames.length : precisionIndex
+  const i = unitNames.indexOf(precision)
   return new Duration(
     i >= 0 ? year * sign : 0,
     i >= 1 ? (month - year * 12) * sign : 0,

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -1,5 +1,6 @@
 import {assert} from '@open-wc/testing'
 import {applyDuration, Duration, elapsedTime, getRelativeTimeUnit, roundToSingleUnit} from '../src/duration.ts'
+import type {Unit} from '../src/duration.ts'
 import type {DurationFormatOptions} from '../src/duration-format-ponyfill.ts'
 import {Temporal} from '@js-temporal/polyfill'
 
@@ -235,6 +236,12 @@ suite('duration', function () {
         input: '2020-10-24T14:46:00.000Z',
         precision: 'year',
         expected: '-P2Y',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2024-10-24T14:46:00.000Z',
+        precision: 'unknown' as Unit,
+        expected: 'PT0S',
       },
     ])
     for (const {input, now, precision = 'millisecond', expected} of elapsed) {

--- a/test/duration.ts
+++ b/test/duration.ts
@@ -224,6 +224,18 @@ suite('duration', function () {
         input: '2023-03-21T16:03:00.000Z',
         expected: '-P1DT20H',
       },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2024-10-24T14:46:00.000Z',
+        precision: 'year',
+        expected: 'P2Y',
+      },
+      {
+        now: '2022-10-24T14:46:00.000Z',
+        input: '2020-10-24T14:46:00.000Z',
+        precision: 'year',
+        expected: '-P2Y',
+      },
     ])
     for (const {input, now, precision = 'millisecond', expected} of elapsed) {
       test(`${input} is ${expected} elapsed from ${now} (precision ${precision})`, () => {

--- a/test/relative-time.js
+++ b/test/relative-time.js
@@ -1564,6 +1564,12 @@ suite('relative-time', function () {
       {
         datetime: '2024-10-24T14:46:00.000Z',
         format: 'duration',
+        precision: 'year',
+        expected: '2 years',
+      },
+      {
+        datetime: '2024-10-24T14:46:00.000Z',
+        format: 'duration',
         precision: 'minute',
         expected: '2 years, 11 days',
       },
@@ -2679,6 +2685,12 @@ suite('relative-time', function () {
         datetime: '2021-10-29T14:46:00.000Z',
         format: 'elapsed',
         expected: '1y',
+      },
+      {
+        datetime: '2020-10-24T14:46:00.000Z',
+        format: 'elapsed',
+        precision: 'year',
+        expected: '2y',
       },
 
       // Dates in the past


### PR DESCRIPTION
## Summary

- honor `precision="year"` when calculating elapsed durations
- preserve the existing empty-duration result for an unknown runtime precision
- cover positive and negative helper results plus rendered `duration` and `elapsed` output

## Root cause

`unitNames.indexOf("year")` returns `0`, but the logical-or expression treated
that valid index as falsy and replaced it with `unitNames.length`. Using the raw
index keeps `0` as the year cutoff and also preserves the existing `-1`
behavior for an unknown runtime value.

## Testing

- `npm test` (634 passing)
- `npm run lint`
- `npm run build`

Fixes #366
